### PR TITLE
FIT-1825 Fatal error fix in php 5.4

### DIFF
--- a/modules/custom/cu_share/cu_share.module
+++ b/modules/custom/cu_share/cu_share.module
@@ -29,7 +29,7 @@ function cu_share_page_alter(&$page) {
     // If social share context reaction was set, do that first
     if ($plugin = context_get_plugin('reaction', 'cu_share')) {
       if ($plugin->execute($page, $op)) {
-        cu_share_output(&$page);
+        cu_share_output($page);
       }
     }
   }
@@ -41,7 +41,7 @@ function cu_share_page_alter(&$page) {
       if ($node = menu_get_object()) {
         $type = $node->type;
         if ($settings[$type]) {
-          cu_share_output(&$page);
+          cu_share_output($page);
         }
       }
     }


### PR DESCRIPTION
Not sure about this possible fix. It runs in PHP 5.3 this way but in php 5.4, &$page causes a fatal error. The call-time pass-by-reference was removed in 5.4. Works in function definitions but not the call.