### PR TITLE
FIT-2282 Added dependency for cu_soundcloud_embed to express.info.

### DIFF
--- a/express.info
+++ b/express.info
@@ -106,6 +106,7 @@ dependencies[] = chain_menu_access
 dependencies[] = cu_wysiwyg
 dependencies[] = cu_shortcodes
 dependencies[] = cu_shortcodes_wysiwyg
+dependencies[] = cu_soundcloud_embed
 dependencies[] = wysiwyg
 dependencies[] = wysiwyg_filter
 dependencies[] = shortcode

--- a/modules/custom/cu_news_bundle/cu_news_bundle.info
+++ b/modules/custom/cu_news_bundle/cu_news_bundle.info
@@ -5,5 +5,6 @@ package = CU-News and Articles
 project_demo_url = http://www.colorado.edu/webcentral/node/676
 
 dependencies[] = cu_article
+dependencies[] = cu_related_articles
 
 bundle_cache_clear = 1


### PR DESCRIPTION
Profile install is ignoring dependencies of dependencies--therefore, cu_shortcodes_wysiwyg_buttons is enabled as a dependency of the profile, but cu_soundcloud_embed--which is a dependency of cu_shortcodes_wysiwyg_buttons--is not enabled during install. 