### PR TITLE
bug/827 Add tab to set Atlas status to 'take_down'.

### DIFF
--- a/modules/custom/atlas/atlas.module
+++ b/modules/custom/atlas/atlas.module
@@ -24,60 +24,7 @@ function atlas_menu() {
     'weight' => -10,
   );
 
-  $items['admin/config/development/atlas/delete-site'] = array(
-    'title' => 'Delete',
-    'type' => MENU_LOCAL_TASK,
-    'description' => 'Take down site.',
-    'page callback' => 'drupal_get_form',
-    'page arguments' => array('atlas_take_down_site_form'),
-    'access arguments' => array('administer modules'),
-    'weight' => 10,
-  );
-
   return $items;
-}
-
-/**
- * Page callback for admin/config/development/atlas/take-down-site.
- */
-function atlas_take_down_site_form($form, &$form_state) {
-  $form = array();
-
-  $form['disclaimer'] = array(
-    '#type' => 'markup',
-    '#prefix' => '<h2>',
-    '#markup' => t('Are you sure you want to delete this site? This action cannot be undone.'),
-    '#suffix' => '</h2><br>',
-  );
-
-  $form['confirm'] = array(
-    '#type' => 'checkbox',
-    '#prefix' => '<h3>',
-    '#title' => t('Yes, delete site.'),
-    '#suffix' => '</h3><br>',
-    '#default_value' => FALSE,
-    '#required' => TRUE,
-  );
-
-  $form['delete-site'] = array(
-    '#title' => t('Delete this site?'),
-    '#description' => t('This will take down your site.'),
-    '#type' => 'submit',
-    '#value' => 'Set status to "take_down" in Atlas',
-  );
-
-  return $form;
-}
-
-function atlas_take_down_site_form_submit($form, &$form_state) {
-  // We need to know the 'atlas_id'.
-  $atlas_id = variable_get('atlas_id', FALSE);
-  $site_array = atlas_api_request('sites', $atlas_id);
-
-  $site_data = $site_array;
-  $site_data['status'] = 'take_down';
-  atlas_api_request('sites', $atlas_id, 'PATCH', $site_data);
-  drupal_set_message(t('The form has been submitted.'));
 }
 
 /**
@@ -103,10 +50,20 @@ function atlas_admin_settings() {
 
   $site_array = atlas_api_request('sites', $atlas_id);
 
+  $form['current_state'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Current Status'),
+  );
+
+  $form['current_state']['state'] = array(
+    '#type' => 'markup',
+    '#markup' => $site_array['status'],
+  );
+
   // Options are limited based on permissions.
   $status_options = array(
     'launching' => t('Launching'),
-    //'take_down' => t('Take Down Site'),
+    'take_down' => t('Take Down Site'),
   );
 
   // If site is Available, Installed, or Launched, add options. You shouldn't

--- a/modules/custom/atlas/atlas.module
+++ b/modules/custom/atlas/atlas.module
@@ -76,13 +76,13 @@ function atlas_admin_settings() {
       'available' => t('Available'),
     );
   }
-  elseif ($site_array['status'] == 'installed') {
+  elseif (($site_array['status'] == 'installed') || ($site_array['status'] == 'installing')) {
     $status_options = array(
       'launching' => t('Launching'),
       'take_down' => t('Take Down Site'),
     );
   }
-  elseif ($site_array['status'] == 'launched') {
+  elseif (($site_array['status'] == 'launched') || ($site_array['status'] == 'launching')) {
     $status_options = array(
       'take_down' => t('Take Down Site'),
     );

--- a/modules/custom/atlas/atlas.module
+++ b/modules/custom/atlas/atlas.module
@@ -24,7 +24,60 @@ function atlas_menu() {
     'weight' => -10,
   );
 
+  $items['admin/config/development/atlas/delete-site'] = array(
+    'title' => 'Delete',
+    'type' => MENU_LOCAL_TASK,
+    'description' => 'Take down site.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('atlas_take_down_site_form'),
+    'access arguments' => array('administer modules'),
+    'weight' => 10,
+  );
+
   return $items;
+}
+
+/**
+ * Page callback for admin/config/development/atlas/take-down-site.
+ */
+function atlas_take_down_site_form($form, &$form_state) {
+  $form = array();
+
+  $form['disclaimer'] = array(
+    '#type' => 'markup',
+    '#prefix' => '<h2>',
+    '#markup' => t('Are you sure you want to delete this site? This action cannot be undone.'),
+    '#suffix' => '</h2><br>',
+  );
+
+  $form['confirm'] = array(
+    '#type' => 'checkbox',
+    '#prefix' => '<h3>',
+    '#title' => t('Yes, delete site.'),
+    '#suffix' => '</h3><br>',
+    '#default_value' => FALSE,
+    '#required' => TRUE,
+  );
+
+  $form['delete-site'] = array(
+    '#title' => t('Delete this site?'),
+    '#description' => t('This will take down your site.'),
+    '#type' => 'submit',
+    '#value' => 'Set status to "take_down" in Atlas',
+  );
+
+  return $form;
+}
+
+function atlas_take_down_site_form_submit($form, &$form_state) {
+  // We need to know the 'atlas_id'.
+  $atlas_id = variable_get('atlas_id', FALSE);
+  $site_array = atlas_api_request('sites', $atlas_id);
+
+  $site_data = $site_array;
+  $site_data['status'] = 'take_down';
+  atlas_api_request('sites', $atlas_id, 'PATCH', $site_data);
+  drupal_set_message(t('The form has been submitted.'));
 }
 
 /**
@@ -53,7 +106,7 @@ function atlas_admin_settings() {
   // Options are limited based on permissions.
   $status_options = array(
     'launching' => t('Launching'),
-    'take_down' => t('Take Down Site'),
+    //'take_down' => t('Take Down Site'),
   );
 
   // If site is Available, Installed, or Launched, add options. You shouldn't

--- a/modules/custom/atlas/atlas.module
+++ b/modules/custom/atlas/atlas.module
@@ -62,6 +62,8 @@ function atlas_admin_settings() {
 
   // Options are limited based on permissions.
   $status_options = array(
+    'installing' => t('Installing'),
+    'available' => t('Available'),
     'launching' => t('Launching'),
     'take_down' => t('Take Down Site'),
   );
@@ -73,15 +75,30 @@ function atlas_admin_settings() {
       'installing' => t('Installing'),
       'available' => t('Available'),
     );
-  }
-  elseif ($site_array['status'] == 'installed') {
-    $status_options['installed'] = t('Installed');
-  }
-  elseif ($site_array['status'] == 'launched') {
-    $status_options['launched'] = t('Launched');
+  } elseif ($site_array['status'] == 'installed') {
+    $status_options = array(
+      'launching' => t('Launching'),
+      'take_down' => t('Take Down Site'),
+    );
+  } elseif ($site_array['status'] == 'launched') {
+    $status_options = array(
+      'take_down' => t('Take Down Site'),
+    );
   }
 
   $form['atlas_status'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Change Site Status'),
+  );
+
+  $form['atlas_status']['check'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Change Site Status?'),
+    '#default_value' => FALSE,
+    '#description' => t('You must check this box in order to change the site status.'),
+  );
+
+  $form['atlas_status']['status'] = array(
     '#type' => 'select',
     '#title' => t('Site Status'),
     '#options' => $status_options,
@@ -191,10 +208,10 @@ function atlas_admin_settings() {
 function validate_atlas_admin_settings($form, &$form_state) {
   $atlas_id = variable_get('atlas_id', FALSE);
   $site_array = atlas_api_request('sites', $atlas_id);
-  if ($form['atlas_path']['#value'] == $site_array['sid'] && $site_array['pool'] != 'poolb-homepage' && ($form['atlas_status']['#value'] == 'launching' || $form['atlas_status']['#value'] == 'launched')) {
+  if ($form['atlas_path']['#value'] == $site_array['sid'] && $site_array['pool'] != 'poolb-homepage' && ($form['atlas_status']['status']['#value'] == 'launching' || $form['atlas_status']['status']['#value'] == 'launched')) {
     form_set_error('atlas_path', t('You cannot launch a site at it\'s \'p1\' URL.'));
   }
-  if ($form['atlas_status']['#value'] == 'available') {
+  if ($form['atlas_status']['status']['#value'] == 'available') {
     form_set_error('atlas_status', t('You cannot make any changes to a site while it is in the \'Available\' state.'));
   }
 }
@@ -211,8 +228,8 @@ function atlas_admin_settings_submit($form, &$form_state) {
 
   // Check to see if the form value is the same as the original item and remove
   // the row if it is.
-  if ($form_state['values']['atlas_status'] != $site_array['status']) {
-    $request_data['status'] = $form_state['values']['atlas_status'];
+  if ($form_state['values']['check']) {
+    $request_data['status'] = $form_state['values']['status'];
   }
 
   if ($form_state['values']['atlas_path'] != $site_array['path']) {

--- a/modules/custom/atlas/atlas.module
+++ b/modules/custom/atlas/atlas.module
@@ -75,12 +75,14 @@ function atlas_admin_settings() {
       'installing' => t('Installing'),
       'available' => t('Available'),
     );
-  } elseif ($site_array['status'] == 'installed') {
+  }
+  elseif ($site_array['status'] == 'installed') {
     $status_options = array(
       'launching' => t('Launching'),
       'take_down' => t('Take Down Site'),
     );
-  } elseif ($site_array['status'] == 'launched') {
+  }
+  elseif ($site_array['status'] == 'launched') {
     $status_options = array(
       'take_down' => t('Take Down Site'),
     );

--- a/modules/custom/atlas/atlas.module
+++ b/modules/custom/atlas/atlas.module
@@ -78,6 +78,7 @@ function atlas_admin_settings() {
   }
   elseif (($site_array['status'] == 'installed') || ($site_array['status'] == 'installing')) {
     $status_options = array(
+      '' => t('Installed placeholder'),
       'launching' => t('Launching'),
       'take_down' => t('Take Down Site'),
     );


### PR DESCRIPTION
Updated: no extra tab. Displays current status and allows users to change the status from available >> installed >> launched >> down.