### PR TITLE
#1156 Added 'other' to statistics payload

### DIFF
--- a/modules/custom/cu_atlas/cu_atlas.module
+++ b/modules/custom/cu_atlas/cu_atlas.module
@@ -252,13 +252,24 @@ function _get_bundle_stats() {
     'cu_test_content_admin_bundle',
     'cu_debug_admin_bundle',
   );
+
+  $other_bundles = array();
+
   foreach ($enabled_bundles as $key => $bundle) {
     if (in_array($bundle->name, $express_bundles)) {
       $bundle_stats[$bundle->name] = array(
         'schema_version' => $bundle->schema_version,
       );
     }
+
+    else {
+      // For non-express bundles concatenate bundle name and schema version
+      // 'bundle_name - schema_version'
+      array_push($other_bundles, $bundle->name . ' - ' . $bundle->schema_version);
+    }
   }
+  // Concatenate strings in $other_bundles array to create one long string.
+  $bundle_stats['other'] = implode("; ", $other_bundles);
   return $bundle_stats;
 }
 

--- a/modules/custom/cu_atlas/cu_atlas.module
+++ b/modules/custom/cu_atlas/cu_atlas.module
@@ -263,8 +263,7 @@ function _get_bundle_stats() {
     }
 
     else {
-      // For non-express bundles concatenate bundle name and schema version
-      // 'bundle_name - schema_version'
+      // For non-express bundles concatenate bundle name and schema version as 'bundle_name - schema_version'
       array_push($other_bundles, $bundle->name . ' - ' . $bundle->schema_version);
     }
   }

--- a/modules/custom/cu_atlas/cu_atlas.module
+++ b/modules/custom/cu_atlas/cu_atlas.module
@@ -263,7 +263,7 @@ function _get_bundle_stats() {
     }
 
     else {
-      // For non-express bundles concatenate bundle name and schema version as 'bundle_name - schema_version'
+      // For non-express bundles concatenate bundle name and schema version as 'bundle_name - schema_version' .
       array_push($other_bundles, $bundle->name . ' - ' . $bundle->schema_version);
     }
   }


### PR DESCRIPTION
#1156 to show enabled non-express bundles. Follows format 'bundle_name - schema version'
```
"bundles": {
		"cu_advanced_layout_bundle": {
			"schema_version": "7001"
		},
		"cu_events_bundle": {
			"schema_version": "0"
		},
		"cu_feeds_bundle": {
			"schema_version": "0"
		},
		"cu_forms_bundle": {
			"schema_version": "0"
		},
		"cu_news_bundle": {
			"schema_version": "0"
		},
		"cu_people_bundle": {
			"schema_version": "0"
		},
		"other": "express_responsive_visibility_bundle - 0"
	}
```