### PR TITLE
Bug/1364 Adding Missing Shortcodes to filter/tips

### DIFF
--- a/modules/contrib/shortcode/shortcode.module
+++ b/modules/contrib/shortcode/shortcode.module
@@ -88,7 +88,7 @@ function _shortcode_filter_tips($filter, $format, $long = FALSE) {
   }
   return theme('item_list',
     array(
-      'title' => t('Shortcodes usage'),
+      'title' => t('Shortcodes Usage'),
       'items' => $tips,
       'type' => 'ol',
     )

--- a/modules/custom/cu_shortcodes/cu_shortcodes.module
+++ b/modules/custom/cu_shortcodes/cu_shortcodes.module
@@ -558,7 +558,7 @@ function cu_shortcodes_column($attrs, $content = NULL) {
  * Column tips.
  */
 function cu_shortcodes_column_tips($format, $long) {
-  $output = '<p>[column size=one-half]</p><p>your content here</p><p>[/column]</p><p>[column size=one-half order=last]</p><p>your content here</p><p>[/column]</p>';
+  $output = '<p>[column size=one-half]</p><p>Your Content Here</p><p>[/column]</p><p>[column size=one-half order=last]</p><p>Your Content Here</p><p>[/column]</p>';
   return $output;
 }
 
@@ -747,7 +747,7 @@ function cu_shortcodes_imagecaption($attrs, $content = NULL) {
  */
 
 function cu_shortcodes_imagecaption_tips($format, $long) {
-  $output = '[imagecaption align="none"]Your image caption here[/imagecaption]';
+  $output = '<p>[imagecaption align="none"]</p> <p>Image</p> <p>Your image caption here</p> <p>[/imagecaption]</p>';
   return $output;
 }
 
@@ -793,7 +793,7 @@ function cu_shortcodes_map($attrs, $content = NULL) {
  * Map tips.
  */
 function cu_shortcodes_map_tips($format, $long) {
-  $output = '[map]https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3054.215386660962!2d-105.26572850973943!3d40.04829405429418!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x876beef682730725%3A0xc7604d66a96a0f1e!2sNorth+Boulder!5e0!3m2!1sen!2sus!4v1400010841644[/map]';
+  $output = '<p>[map]https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3054.215386660962!2d-105.26572850973943!3d40.04829405429418!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x876beef682730725%3A0xc7604d66a96a0f1e!2sNorth+Boulder!5e0!3m2!1sen!2sus!4v1400010841644[/map]</p>';
   return $output;
 }
 

--- a/modules/custom/cu_shortcodes/cu_shortcodes.module
+++ b/modules/custom/cu_shortcodes/cu_shortcodes.module
@@ -944,7 +944,7 @@ function cu_shortcodes_tweet($attrs, $content = NULL) {
 }
 
 /**
- * Get tweet tips.
+ * Get Tweet tips.
  *
  * @return string
  *   Returns output.

--- a/modules/custom/cu_shortcodes/cu_shortcodes.module
+++ b/modules/custom/cu_shortcodes/cu_shortcodes.module
@@ -682,7 +682,7 @@ function cu_shortcodes_googlecalendar($attrs, $content = NULL ) {
 }
 
 function cu_shortcodes_googlecalendar_tips($format, $long) {
-  $output = '[googlecalendar]https://www.google.com/calendar/embed?title=Faculty%20Planning%20Calendar&height=600&wkst=1&bgcolor=%23FFFFFF&src=fqd9tj22sodte3oosui2h5e13o%40group.calendar.google.com&color=%23875509&src=270ehpc2jeu16j00p4st3nvb2c%40group.calendar.google.com&color=%2342104A&src=jm056q7sfv17ngqj3e4ph60iuk%40group.calendar.google.com&color=%232952A3&src=jazzmountainclimber%40gmail.com&color=%23711616&src=hgk9ielvps4qkv7uehs6q8rc18%40group.calendar.google.com&color=%232F6309&src=625jneetmcajuamdvv3as9tft8%40group.calendar.google.com&color=%236B3304&src=en.usa%23holiday%40group.v.calendar.google.com&color=%23125A12&ctz=America%2FDenver[/googlecalendar]';
+  $output = '[googlecalendar]YOUR GOOGLE CALENDAR EMBED URL[/googlecalendar]';
   return $output;
 }
 
@@ -793,7 +793,7 @@ function cu_shortcodes_map($attrs, $content = NULL) {
  * Map tips.
  */
 function cu_shortcodes_map_tips($format, $long) {
-  $output = '[map]https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3054.215386660962!2d-105.26572850973943!3d40.04829405429418!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x876beef682730725%3A0xc7604d66a96a0f1e!2sNorth+Boulder!5e0!3m2!1sen!2sus!4v1400010841644[/map]';
+  $output = '[map]YOUR GOOGLE MAPS EMBED URL[/map]';
   return $output;
 }
 

--- a/modules/custom/cu_shortcodes/cu_shortcodes.module
+++ b/modules/custom/cu_shortcodes/cu_shortcodes.module
@@ -745,7 +745,6 @@ function cu_shortcodes_imagecaption($attrs, $content = NULL) {
 /**
  * Image Caption tips.
  */
-
 function cu_shortcodes_imagecaption_tips($format, $long) {
   $output = '<p>[imagecaption align="none"]</p> <p>Image</p> <p>Your image caption here</p> <p>[/imagecaption]</p>';
   return $output;

--- a/modules/custom/cu_shortcodes/cu_shortcodes.module
+++ b/modules/custom/cu_shortcodes/cu_shortcodes.module
@@ -234,7 +234,7 @@ function cu_shortcodes_shortcode_info() {
   );
   $shortcodes['map'] = array(
     'title' => t('Map'),
-    'description' => t('Insert a Google Map'),
+    'description' => t('Insert a Campus or Google Map'),
     'process callback' => 'cu_shortcodes_map',
     'tips callback' => 'cu_shortcodes_map_tips',
     'default settings' => array(),
@@ -792,7 +792,7 @@ function cu_shortcodes_map($attrs, $content = NULL) {
  * Map tips.
  */
 function cu_shortcodes_map_tips($format, $long) {
-  $output = '[map]YOUR GOOGLE MAPS EMBED URL[/map]';
+  $output = '<p>[map size="small/medium/large"]YOUR GOOGLE MAPS EMBED URL[/map]</p><p>[map size="small/medium/large"]YOUR CAMPUS MAP URL[/map]</p>';
   return $output;
 }
 
@@ -800,7 +800,8 @@ function cu_shortcodes_map_tips($format, $long) {
  * Map demo.
  */
 function cu_shortcodes_map_demo() {
-  $output = '<iframe width="100%" height="325" src="https://maps.google.com/?ll=40.079122,-105.088348&spn=0.166286,0.245132&t=m&z=12&amp;ie=UTF8&amp;output=embed"></iframe><br /><a href="https://maps.google.com/?ll=40.079122,-105.088348&spn=0.166286,0.245132&t=m&z=12&amp;ie=UTF8&amp;output=embed">View Larger Map</a>';
+  $output = '<iframe width="100%" height="325" src="https://maps.google.com/?ll=40.079122,-105.088348&spn=0.166286,0.245132&t=m&z=12&amp;ie=UTF8&amp;output=embed"></iframe><br /><a href="https://maps.google.com/?ll=40.079122,-105.088348&spn=0.166286,0.245132&t=m&z=12&amp;ie=UTF8&amp;output=embed">View Larger Map</a> <iframe width="100%" height="325" src="https://www.colorado.edu/map/?id=336&em=1&open=0#?mc/40.004375,-105.264969?z/18"></iframe><a href="https://www.colorado.edu/map/?id=336&em=1&open=0#?mc/40.004375,-105.264969?z/18?sbc">View Larger Map</a>';
+
   return $output;
 }
 /**
@@ -944,7 +945,7 @@ function cu_shortcodes_tweet($attrs, $content = NULL) {
 }
 
 /**
- * Get Tweet tips.
+ * Get tweet tips.
  *
  * @return string
  *   Returns output.

--- a/modules/custom/cu_shortcodes/cu_shortcodes.module
+++ b/modules/custom/cu_shortcodes/cu_shortcodes.module
@@ -793,7 +793,7 @@ function cu_shortcodes_map($attrs, $content = NULL) {
  * Map tips.
  */
 function cu_shortcodes_map_tips($format, $long) {
-  $output = '<p>[map]https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3054.215386660962!2d-105.26572850973943!3d40.04829405429418!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x876beef682730725%3A0xc7604d66a96a0f1e!2sNorth+Boulder!5e0!3m2!1sen!2sus!4v1400010841644[/map]</p>';
+  $output = '[map]https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3054.215386660962!2d-105.26572850973943!3d40.04829405429418!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x876beef682730725%3A0xc7604d66a96a0f1e!2sNorth+Boulder!5e0!3m2!1sen!2sus!4v1400010841644[/map]';
   return $output;
 }
 

--- a/modules/custom/cu_shortcodes/cu_shortcodes.module
+++ b/modules/custom/cu_shortcodes/cu_shortcodes.module
@@ -229,6 +229,7 @@ function cu_shortcodes_shortcode_info() {
     'title' => t('Image Caption'),
     'description' => t('Add a caption to an image'),
     'process callback' => 'cu_shortcodes_imagecaption',
+    'tips callback' => 'cu_shortcodes_imagecaption_tips',
     'default settings' => array(),
   );
   $shortcodes['map'] = array(
@@ -681,7 +682,7 @@ function cu_shortcodes_googlecalendar($attrs, $content = NULL ) {
 }
 
 function cu_shortcodes_googlecalendar_tips($format, $long) {
-  $output = '[calendar]https://www.google.com/calendar/embed?title=Faculty%20Planning%20Calendar&height=600&wkst=1&bgcolor=%23FFFFFF&src=fqd9tj22sodte3oosui2h5e13o%40group.calendar.google.com&color=%23875509&src=270ehpc2jeu16j00p4st3nvb2c%40group.calendar.google.com&color=%2342104A&src=jm056q7sfv17ngqj3e4ph60iuk%40group.calendar.google.com&color=%232952A3&src=jazzmountainclimber%40gmail.com&color=%23711616&src=hgk9ielvps4qkv7uehs6q8rc18%40group.calendar.google.com&color=%232F6309&src=625jneetmcajuamdvv3as9tft8%40group.calendar.google.com&color=%236B3304&src=en.usa%23holiday%40group.v.calendar.google.com&color=%23125A12&ctz=America%2FDenver[/calendar]';
+  $output = '[googlecalendar]https://www.google.com/calendar/embed?title=Faculty%20Planning%20Calendar&height=600&wkst=1&bgcolor=%23FFFFFF&src=fqd9tj22sodte3oosui2h5e13o%40group.calendar.google.com&color=%23875509&src=270ehpc2jeu16j00p4st3nvb2c%40group.calendar.google.com&color=%2342104A&src=jm056q7sfv17ngqj3e4ph60iuk%40group.calendar.google.com&color=%232952A3&src=jazzmountainclimber%40gmail.com&color=%23711616&src=hgk9ielvps4qkv7uehs6q8rc18%40group.calendar.google.com&color=%232F6309&src=625jneetmcajuamdvv3as9tft8%40group.calendar.google.com&color=%236B3304&src=en.usa%23holiday%40group.v.calendar.google.com&color=%23125A12&ctz=America%2FDenver[/googlecalendar]';
   return $output;
 }
 
@@ -738,6 +739,15 @@ function cu_shortcodes_imagecaption($attrs, $content = NULL) {
 
       ), $attrs));
   $output = '<div class="image-caption image-caption-' . $align . '">' . $content . '</div>';
+  return $output;
+}
+
+/**
+ * Image Caption tips.
+ */
+
+function cu_shortcodes_imagecaption_tips($format, $long) {
+  $output = '[imagecaption align="none"]Your image caption here[/imagecaption]';
   return $output;
 }
 


### PR DESCRIPTION
Changes to site/filter/tips

- Added imagecaption usage example, 
- Updated maps to googlemaps usage example.
- Twitter usage remains hidden until cu_share module is enabled.
- Made minor text updates to prevent text from overflowing on google maps and calendar examples.