### PR TITLE
Bug/2300

### DIFF
--- a/modules/custom/express_permissions/express_permissions.module
+++ b/modules/custom/express_permissions/express_permissions.module
@@ -924,13 +924,18 @@ function express_permissions_get_site_owners() {
  */
 function express_permissions_form_user_admin_permissions_alter(&$form, &$form_state) {
   $roles = $form['role_names'];
+  dpm($roles);
   // Get just the role arrays.
   $roles = array_intersect_key($roles, array_flip(element_children($roles)));
+  // Get the role id to modify form array
+  $roles_keys = array_keys($roles);
+
   // Replace underscores with spaces.
-  foreach ($roles as $id) {
+  foreach ($roles_keys as $id) {
     $name = str_replace('_', ' ', $form['role_names'][$id]['#markup']);
     $form['role_names'][$id]['#markup'] = $name;
   }
+
   // Add some css to make the permissions table headers smaller.
   drupal_add_css('form#user-admin-permissions #permissions th { font-size:75%; font-weight:bold; } form#user-admin-permissions #permissions .permission-machine-name { font-size:75%; opacity:.75;}', 'inline');
 }

--- a/modules/custom/express_permissions/express_permissions.module
+++ b/modules/custom/express_permissions/express_permissions.module
@@ -924,7 +924,6 @@ function express_permissions_get_site_owners() {
  */
 function express_permissions_form_user_admin_permissions_alter(&$form, &$form_state) {
   $roles = $form['role_names'];
-  dpm($roles);
   // Get just the role arrays.
   $roles = array_intersect_key($roles, array_flip(element_children($roles)));
   // Get the role id to modify form array


### PR DESCRIPTION
The headers that have the role names now have the underscore removed correctly, this should fix the `Warning: Illegal offset type in express_permissions_form_user_admin_permissions_alter()` error we've been seeing.