### PR TITLE
Updating bundle description link

### DIFF
--- a/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
+++ b/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
@@ -163,7 +163,7 @@ function curl_github_info($hash, $name) {
       // Shave it for later.
       variable_set('github_info', $github_info);
     } else {
-      $output = 'For information on this and other bundles that require a request, visit <a href="http://colorado.edu/webcentral">Webcentral\'s page about bundle requests.</a>';
+      $output = 'For information on this and other bundles that require a request, visit <a href="https://www.colorado.edu/webcentral/web-express-features/bundles-features/request-add-bundles">Webcentral\'s page about bundle requests.</a>';
     }
   } else {
     $output = $github_info[$name];

--- a/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
+++ b/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
@@ -278,7 +278,7 @@ function cu_profile_module_manager_request_page() {
   $output = array(
     'description' => array(
       '#type' => 'markup',
-      '#markup' => '<p>These are bundles that must be requested from <a href="http://colorado.edu/webcentral">Webcentral</a> by site owners. Once you add the bundle,
+      '#markup' => '<p>These are bundles that must be requested from <a href="https://www.colorado.edu/webcentral/web-express-features/bundles-features/request-add-bundles">Webcentral</a> by site owners. Once you add the bundle,
                     you will receive an email when it has finished downloading. Once downloaded, the bundle will
                     be available to enable on this page.</p>',
     ),

--- a/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
+++ b/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
@@ -163,7 +163,7 @@ function curl_github_info($hash, $name) {
       // Shave it for later.
       variable_set('github_info', $github_info);
     } else {
-      $output = 'For information on this and other bundles that require a request, visit <a href="https://www.colorado.edu/webcentral/web-express-features/bundles-features/request-add-bundles">Webcentral\'s page about bundle requests.</a>';
+      $output = 'For information on this and other bundles that require a request, visit <a href="https://www.colorado.edu/webcentral/node/1522/">Webcentral\'s page about bundle requests.</a>';
     }
   } else {
     $output = $github_info[$name];
@@ -278,7 +278,7 @@ function cu_profile_module_manager_request_page() {
   $output = array(
     'description' => array(
       '#type' => 'markup',
-      '#markup' => '<p>These are bundles that must be requested from <a href="https://www.colorado.edu/webcentral/web-express-features/bundles-features/request-add-bundles">Webcentral</a> by site owners. Once you add the bundle,
+      '#markup' => '<p>These are bundles that must be requested from <a href="https://www.colorado.edu/webcentral/node/1522/">Webcentral</a> by site owners. Once you add the bundle,
                     you will receive an email when it has finished downloading. Once downloaded, the bundle will
                     be available to enable on this page.</p>',
     ),


### PR DESCRIPTION
#1994 Linking users to https://www.colorado.edu/webcentral/web-express-features/bundles-features/request-add-bundles instead of Web Central Homepage