### PR TITLE
Feature/2603 Override output of addon, request, and beta bundles when…

### DIFF
--- a/modules/custom/cu_core/cu_core.install
+++ b/modules/custom/cu_core/cu_core.install
@@ -73,7 +73,7 @@ function cu_core_install() {
 
   // Set message for when enabling of bundles is turned off.
   variable_set('profile_module_manager_disable_enabling_atlas_bundles', 0);
-  variable_set('profile_module_manager_disable_enabling_text', 'Due to unexpectedly high load on the servers, the option to enable bundles has temporarily been disabled.  Please check back tomorrow.');
+  variable_set('profile_module_manager_disable_enabling_text', 'Bundles are not available at this time. Contact websupport@colorado.edu for questions regarding this.');
   variable_set('rave_alerts_rss_url', 'http://www.getrave.com/rss/cuboulder/channel1');
   variable_set('rave_alerts_check_enable', 1);
   variable_set('rave_alerts_network_fail_message', 'Network Failure: Please go directly to http://alerts.colorado.edu for more information.');

--- a/modules/custom/cu_core/cu_core.install
+++ b/modules/custom/cu_core/cu_core.install
@@ -72,7 +72,7 @@ function cu_core_install() {
   variable_set('express_help_base_url', 'http://www.colorado.edu/webcentral');
 
   // Set message for when enabling of bundles is turned off.
-  variable_set('profile_module_manager_disable_enabling', 0);
+  variable_set('profile_module_manager_disable_enabling_atlas_bundles', 0);
   variable_set('profile_module_manager_disable_enabling_text', 'Due to unexpectedly high load on the servers, the option to enable bundles has temporarily been disabled.  Please check back tomorrow.');
   variable_set('rave_alerts_rss_url', 'http://www.getrave.com/rss/cuboulder/channel1');
   variable_set('rave_alerts_check_enable', 1);

--- a/modules/custom/cu_core/cu_core.install
+++ b/modules/custom/cu_core/cu_core.install
@@ -72,6 +72,7 @@ function cu_core_install() {
   variable_set('express_help_base_url', 'http://www.colorado.edu/webcentral');
 
   // Set message for when enabling of bundles is turned off.
+  variable_set('profile_module_manager_disable_enabling', 0);
   variable_set('profile_module_manager_disable_enabling_text', 'Due to unexpectedly high load on the servers, the option to enable bundles has temporarily been disabled.  Please check back tomorrow.');
   variable_set('rave_alerts_rss_url', 'http://www.getrave.com/rss/cuboulder/channel1');
   variable_set('rave_alerts_check_enable', 1);

--- a/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
+++ b/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
@@ -181,6 +181,11 @@ function cu_profile_module_manager_addon_page() {
   /* Variables and whatnot--no form elements. */
   global $base_path;
 
+  if (variable_get('profile_module_manager_disable_enabling', 0) == 1) {
+    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'The ability to enable bundles has been turned off.') . '</p>';
+    return $output;
+  }
+
   $atlas_id = variable_get('atlas_id', NULL);
 
   drupal_add_css(drupal_get_path('module', 'cu_profile_module_manager') . '/css/cu-profile-module-manager.css', array('group' => CSS_DEFAULT));
@@ -262,6 +267,11 @@ function cu_profile_module_manager_request_page() {
   /* Variables and whatnot--no form elements. */
   global $base_path;
 
+  if (variable_get('profile_module_manager_disable_enabling', 0) == 1) {
+    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'The ability to enable bundles has been turned off.') . '</p>';
+    return $output;
+  }
+
   $atlas_id = variable_get('atlas_id', NULL);
   $site_array = atlas_api_request('sites', $atlas_id);
   if (isset($site_array['code']['package'])) {
@@ -342,6 +352,11 @@ function cu_profile_module_manager_request_page() {
 function cu_profile_module_manager_beta_page() {
   /* Variables and whatnot--no form elements. */
   global $base_path;
+
+  if (variable_get('profile_module_manager_disable_enabling', 0) == 1) {
+    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'The ability to enable bundles has been turned off.') . '</p>';
+    return $output;
+  }
 
   $atlas_id = variable_get('atlas_id', NULL);
   $site_array = atlas_api_request('sites', $atlas_id);

--- a/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
+++ b/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
@@ -182,7 +182,7 @@ function cu_profile_module_manager_addon_page() {
   global $base_path;
 
   if (variable_get('profile_module_manager_disable_enabling_atlas_bundles', 0) == 1) {
-    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'Bundles are not available at this time due to the Server Infrastructure Upgrade. Bundles will be available once a site has migrated to the new infrastructure. Contact websupport@colorado.edu for questions regarding this.') . '</p>';
+    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'Bundles are not available at this time. Contact websupport@colorado.edu for questions regarding this.') . '</p>';
     return $output;
   }
 
@@ -268,7 +268,7 @@ function cu_profile_module_manager_request_page() {
   global $base_path;
 
   if (variable_get('profile_module_manager_disable_enabling_atlas_bundles', 0) == 1) {
-    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'Bundles are not available at this time due to the Server Infrastructure Upgrade. Bundles will be available once a site has migrated to the new infrastructure. Contact websupport@colorado.edu for questions regarding this.') . '</p>';
+    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'Bundles are not available at this time. Contact websupport@colorado.edu for questions regarding this.') . '</p>';
     return $output;
   }
 
@@ -354,7 +354,7 @@ function cu_profile_module_manager_beta_page() {
   global $base_path;
 
   if (variable_get('profile_module_manager_disable_enabling_atlas_bundles', 0) == 1) {
-    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'Bundles are not available at this time due to the Server Infrastructure Upgrade. Bundles will be available once a site has migrated to the new infrastructure. Contact websupport@colorado.edu for questions regarding this.') . '</p>';
+    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'Bundles are not available at this time. Contact websupport@colorado.edu for questions regarding this.') . '</p>';
     return $output;
   }
 

--- a/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
+++ b/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
@@ -182,7 +182,7 @@ function cu_profile_module_manager_addon_page() {
   global $base_path;
 
   if (variable_get('profile_module_manager_disable_enabling_atlas_bundles', 0) == 1) {
-    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'The ability to enable bundles has been turned off.') . '</p>';
+    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'Bundles are not available at this time due to the Server Infrastructure Upgrade. Bundles will be available once a site has migrated to the new infrastructure. Contact websupport@colorado.edu for questions regarding this.') . '</p>';
     return $output;
   }
 
@@ -268,7 +268,7 @@ function cu_profile_module_manager_request_page() {
   global $base_path;
 
   if (variable_get('profile_module_manager_disable_enabling_atlas_bundles', 0) == 1) {
-    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'The ability to enable bundles has been turned off.') . '</p>';
+    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'Bundles are not available at this time due to the Server Infrastructure Upgrade. Bundles will be available once a site has migrated to the new infrastructure. Contact websupport@colorado.edu for questions regarding this.') . '</p>';
     return $output;
   }
 
@@ -354,7 +354,7 @@ function cu_profile_module_manager_beta_page() {
   global $base_path;
 
   if (variable_get('profile_module_manager_disable_enabling_atlas_bundles', 0) == 1) {
-    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'The ability to enable bundles has been turned off.') . '</p>';
+    $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'Bundles are not available at this time due to the Server Infrastructure Upgrade. Bundles will be available once a site has migrated to the new infrastructure. Contact websupport@colorado.edu for questions regarding this.') . '</p>';
     return $output;
   }
 

--- a/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
+++ b/modules/custom/cu_profile_module_manager/cu_profile_module_manager.module
@@ -181,7 +181,7 @@ function cu_profile_module_manager_addon_page() {
   /* Variables and whatnot--no form elements. */
   global $base_path;
 
-  if (variable_get('profile_module_manager_disable_enabling', 0) == 1) {
+  if (variable_get('profile_module_manager_disable_enabling_atlas_bundles', 0) == 1) {
     $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'The ability to enable bundles has been turned off.') . '</p>';
     return $output;
   }
@@ -267,7 +267,7 @@ function cu_profile_module_manager_request_page() {
   /* Variables and whatnot--no form elements. */
   global $base_path;
 
-  if (variable_get('profile_module_manager_disable_enabling', 0) == 1) {
+  if (variable_get('profile_module_manager_disable_enabling_atlas_bundles', 0) == 1) {
     $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'The ability to enable bundles has been turned off.') . '</p>';
     return $output;
   }
@@ -353,7 +353,7 @@ function cu_profile_module_manager_beta_page() {
   /* Variables and whatnot--no form elements. */
   global $base_path;
 
-  if (variable_get('profile_module_manager_disable_enabling', 0) == 1) {
+  if (variable_get('profile_module_manager_disable_enabling_atlas_bundles', 0) == 1) {
     $output = '<p>' . variable_get('profile_module_manager_disable_enabling_text', 'The ability to enable bundles has been turned off.') . '</p>';
     return $output;
   }


### PR DESCRIPTION
… profile_module_manager_disable_enabling is on.

I'm overriding the output before we even make any calls to retrieve bundles or their information.

#2603 