### PR TITLE
Photo gallery images endpoint updated, images now are saved with .jpe…

### DIFF
--- a/modules/custom/cu_test_content_admin_bundle/cu_test_content_gallery/cu_test_content_gallery.install
+++ b/modules/custom/cu_test_content_admin_bundle/cu_test_content_gallery/cu_test_content_gallery.install
@@ -20,7 +20,6 @@ function cu_test_content_gallery_install() {
 
     $file = (object) array(
       'uid' => $count,
-      'filename' => "test".$i.".jpg",
       'uri' => $file_path,
       'filemime' => file_get_mimetype($file_path),
       'status' => 1,

--- a/modules/custom/cu_test_content_admin_bundle/cu_test_content_gallery/cu_test_content_gallery.install
+++ b/modules/custom/cu_test_content_admin_bundle/cu_test_content_gallery/cu_test_content_gallery.install
@@ -15,10 +15,12 @@ function cu_test_content_gallery_install() {
   $node->uid = 1;
   $count = 0;
   for($i=0; $i < 11; $i++) {
-    $file_path = system_retrieve_file('https://picsum.photos/1500/1000/?random');
+    $random = rand(1,96);
+    $file_path = system_retrieve_file('https://picsum.photos/1500/1000/?image=' . $random);
 
     $file = (object) array(
       'uid' => $count,
+      'filename' => "test".$i.".jpg",
       'uri' => $file_path,
       'filemime' => file_get_mimetype($file_path),
       'status' => 1,
@@ -26,7 +28,8 @@ function cu_test_content_gallery_install() {
 
 
     // You can specify a subdirectory, e.g. public://foo/
-    $file = file_copy($file, 'public://');
+    // Appending extension to file name so images load properly when viewed
+    $file = file_copy($file, 'public://'.'test_image_'.$i.'.jpg');
     $node->field_photo[LANGUAGE_NONE][$count] = (array) $file;
     $node->field_photo[LANGUAGE_NONE][$count]['alt'] = _cu_test_content_gallery_dummy_text();
     $node->field_photo[LANGUAGE_NONE][$count]['title'] = _cu_test_content_gallery_dummy_text();


### PR DESCRIPTION
…g file extension #2350

To test:

1. Enable `cu_test_content_gallery`
2. Go to the page where the Photo Gallery was created 
3. Click an image, image should load and expand.