### PR TITLE
admin/people can now be sorted by roles access manager and configurat…

### DIFF
--- a/modules/custom/express_permissions/express_permissions.module
+++ b/modules/custom/express_permissions/express_permissions.module
@@ -956,8 +956,6 @@ function express_permissions_form_user_admin_permissions_alter(&$form, &$form_st
 function express_permissions_form_views_exposed_form_alter(&$form, &$form_state) {
   $hidden_roles_array = array(
     'edit_only',
-    'access_manager',
-    'configuration_manager',
     'administrator',
     'developer',
   );


### PR DESCRIPTION
…ion manager #2576 

To test go to `admin/people` and check that `access_manager` and `configuration_manager` are options in the sort by roles dropdown. 

![screen shot 2018-06-21 at 9 40 19 am](https://user-images.githubusercontent.com/8441552/41729724-2b07d8b8-7537-11e8-9a2f-892bd22272b3.png)
