### PR TITLE
adding class for hiding honeypot field #2660

### DIFF
--- a/modules/custom/cu_core/css/cu-core.css
+++ b/modules/custom/cu_core/css/cu-core.css
@@ -22,3 +22,5 @@
 
 .environment-test.status-launched #navbar-administration #navbar-bar .express-environment-indicator, .environment-test.status-launched .express-environment-indicator { background: #7E57C2; color: #fff; }
 .environment-test.status-launched #navbar-administration #navbar-bar .express-environment-indicator *, .environment-test.status-launched .express-environment-indicator * { color: inherit; }
+
+.url-textfield { display: none !important; }

--- a/modules/custom/cu_core/scss/cu-core.scss
+++ b/modules/custom/cu_core/scss/cu-core.scss
@@ -99,3 +99,10 @@
     }
   }
 }
+
+// Honeypot css
+// $honeypot_element_name = variable_get('honeypot_element_name', 'url');
+// If we ever change this variable we need to update this class name.
+.url-textfield {
+  display: none !important;
+}


### PR DESCRIPTION
To test:

1. Create a webform
2. Go to admin/settings/forms/feedback and set the form you just created as the feedback form
3. Go to a non-admin page on the site - also, NOT the webform node itself

## expected result
You should not see the honeypot field

## current result
You should see the honeypot field