### PR TITLE
Add role to osr test user on login

### DIFF
--- a/modules/custom/cu_users/cu_users.module
+++ b/modules/custom/cu_users/cu_users.module
@@ -798,8 +798,9 @@ function cu_users_user_login(&$edit, $account)
     $account_role = cu_users_get_user_role($user_name);
     // Grab role name id
     $account_role_object_id = user_role_load_by_name($account_role)->rid;
-    // See if user has role that us defined in code
+    // See if user has role that is defined in code
     if (!array_key_exists($account_role_object_id, $account->roles)) {
+      // If user doesn't have the role they should, append the role to the existing role array
       $account->roles += array($account_role_object_id => $account_role);
       user_save($account);
     }

--- a/modules/custom/cu_users/cu_users.module
+++ b/modules/custom/cu_users/cu_users.module
@@ -47,9 +47,39 @@ function cu_users_get_users($type = 'all') {
     'osr-test-edit-own' => 'osr-test-edit-own@colorado.edu',
   );
 
+  $user_array['site_editor'] = array(
+    'osr-test-site-editor' => 'osr-test-site-editor@colorado.edu',
+  );
+
+  $user_array['edit_only'] = array(
+    'osr-test-edit-only' => 'osr-test-edit-only@colorado.edu',
+  );
+
+  $user_array['access_manager'] = array(
+    'osr-test-access-mgr' => 'osr-test-access-mgr@colorado.edu',
+  );
+
+  $user_array['configuration_manager'] = array(
+    'osr-test-config-mgr' => 'osr-test-config-mgr@colorado.edu',
+  );
+
+  $user_array['roles'] = array();
+
+  foreach ($user_array as $key => $user) {
+    foreach ($user as $name => $email) {
+      $user_array['roles'][$name] = $key;
+    }
+  }
+
+
   $user_array['all'] = array_merge($user_array['developer'], $user_array['administrator'], $user_array['site_owner'], $user_array['content_editor'], $user_array['edit_my_content']);
 
   return $user_array[$type];
+}
+
+function cu_users_get_user_role ($user) {
+  $user_list = cu_users_get_users('roles');
+  return $user_list[$user];
 }
 
 /**
@@ -749,5 +779,32 @@ function cu_users_username_alter(&$name, $account) {
   $all = cu_users_get_users($type = 'all');
   if (array_key_exists($account->name, $all)) {
     $name = $name . ' (Web Express Team)';
+  }
+}
+
+/**
+ * Implements hook_user_login().
+ * Assign appropriate role to web express team user
+ */
+function cu_users_user_login(&$edit, $account)
+{
+  // Grab username
+  $user_name = $account->name;
+  // Grab list of all users in web express team
+  $all = cu_users_get_users($type = 'all');
+  // Check that user that logged in in web express team list
+  if (array_key_exists($user_name, $all)) {
+    dpm('user in web express team');
+
+    // Grab role name string that user should have
+    $account_role = cu_users_get_user_role($user_name);
+    // Grab role name id
+    $account_role_object_id = user_role_load_by_name($account_role)->rid;
+
+    // See if user has role that us defined in code
+    if (!array_key_exists($account_role_object_id, $account->roles)) {
+      $account->roles += array($account_role_object_id => $account_role);
+      user_save($account);
+    }
   }
 }

--- a/modules/custom/cu_users/cu_users.module
+++ b/modules/custom/cu_users/cu_users.module
@@ -794,13 +794,10 @@ function cu_users_user_login(&$edit, $account)
   $all = cu_users_get_users($type = 'all');
   // Check that user that logged in in web express team list
   if (array_key_exists($user_name, $all)) {
-    dpm('user in web express team');
-
     // Grab role name string that user should have
     $account_role = cu_users_get_user_role($user_name);
     // Grab role name id
     $account_role_object_id = user_role_load_by_name($account_role)->rid;
-
     // See if user has role that us defined in code
     if (!array_key_exists($account_role_object_id, $account->roles)) {
       $account->roles += array($account_role_object_id => $account_role);


### PR DESCRIPTION
To test login with an osr test account, upon login you should have the corresponding role for that test user.

```
  $user_array['site_owner'] = array(
    'osr-test-owner' => 'osr-test-owner@colorado.edu',
  );

  $user_array['content_editor'] = array(
    'osr-test-content' => 'osr-test-content@colorado.edu',
  );

  $user_array['edit_my_content'] = array(
    'osr-test-edit-own' => 'osr-test-edit-own@colorado.edu',
  );

  $user_array['site_editor'] = array(
    'osr-test-site-editor' => 'osr-test-site-editor@colorado.edu',
  );

  $user_array['edit_only'] = array(
    'osr-test-edit-only' => 'osr-test-edit-only@colorado.edu',
  );

  $user_array['access_manager'] = array(
    'osr-test-access-mgr' => 'osr-test-access-mgr@colorado.edu',
  );

  $user_array['configuration_manager'] = array(
    'osr-test-config-mgr' => 'osr-test-config-mgr@colorado.edu',
  );
```

