### PR TITLE
Testing/71 Add tests for Advanced Design bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,21 +39,9 @@ install:
   - export BUNDLE_NAME="null"
 
   # Behat tags. Allows you to include/exclude tags per bundle as needed.
- # - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript"
- # - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
- # - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
- 
- # ---- the following are Cathy specific
-   # run-js-tests.sh
-  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@AdvDesign"
- 
- # behat-tests.sh
-  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript&&@AdvDesign"
- 
-  # also behat-tests.sh
-  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@AdvDesign"
- 
-# ---- end Cathy specific
+  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript"
+  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
+  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
 
   # Copy scripts to root.
   - cp -R ${ROOT_DIR}/express/tests/travis-ci/* ${ROOT_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ install:
   - export BUNDLE_NAME="null"
 
   # Behat tags. Allows you to include/exclude tags per bundle as needed.
-  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@AdvDesign"
-  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript&&@AdvDesign"
-  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@AdvDesign"
+  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript"
+  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
+  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
 
   # Copy scripts to root.
   - cp -R ${ROOT_DIR}/express/tests/travis-ci/* ${ROOT_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ install:
   - export BUNDLE_NAME="null"
 
   # Behat tags. Allows you to include/exclude tags per bundle as needed.
-  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript"
-  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
-  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
+  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@AdvDesign"
+  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript&&@AdvDesign"
+  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@AdvDesign"
 
   # Copy scripts to root.
   - cp -R ${ROOT_DIR}/express/tests/travis-ci/* ${ROOT_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ install:
   - export BUNDLE_NAME="null"
 
   # Behat tags. Allows you to include/exclude tags per bundle as needed.
-  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript"
-  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
-  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
+  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@AdvancedDesign"
+  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript&&@AdvancedDesign"
+  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@AdvancedDesign"
 
   # Copy scripts to root.
   - cp -R ${ROOT_DIR}/express/tests/travis-ci/* ${ROOT_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,10 @@ install:
   - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@blockmenuicons"
  
  # behat-tests.sh
- # - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
+  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript&&@blockmenuicons"
  
   # also behat-tests.sh
- # - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
+  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@blockmenuicons"
  
 # ---- end Cathy specific
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
  
  # ---- the following are Cathy specific
    # run-js-tests.sh
- # - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@@blockmenuicons"
+  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@blockmenuicons"
  
  # behat-tests.sh
  # - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,13 +45,13 @@ install:
  
  # ---- the following are Cathy specific
    # run-js-tests.sh
-  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@blockmenuicons"
+  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@AdvDesign"
  
  # behat-tests.sh
-  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript&&@blockmenuicons"
+  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript&&@AdvDesign"
  
   # also behat-tests.sh
-  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@blockmenuicons"
+  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@AdvDesign"
  
 # ---- end Cathy specific
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ install:
   - export BUNDLE_NAME="null"
 
   # Behat tags. Allows you to include/exclude tags per bundle as needed.
-  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@AdvancedDesign"
-  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript&&@AdvancedDesign"
-  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@AdvancedDesign"
+  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript"
+  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
+  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
 
   # Copy scripts to root.
   - cp -R ${ROOT_DIR}/express/tests/travis-ci/* ${ROOT_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ install:
   - export BUNDLE_NAME="null"
 
   # Behat tags. Allows you to include/exclude tags per bundle as needed.
-  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript"
-  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
-  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
+  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&AdvDesign"
+  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript&&AdvDesign"
+  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&AdvDesign"
 
   # Copy scripts to root.
   - cp -R ${ROOT_DIR}/express/tests/travis-ci/* ${ROOT_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ install:
   - export BUNDLE_NAME="null"
 
   # Behat tags. Allows you to include/exclude tags per bundle as needed.
-  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&AdvDesign"
-  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript&&AdvDesign"
-  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&AdvDesign"
+  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript"
+  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
+  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
 
   # Copy scripts to root.
   - cp -R ${ROOT_DIR}/express/tests/travis-ci/* ${ROOT_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,21 @@ install:
   - export BUNDLE_NAME="null"
 
   # Behat tags. Allows you to include/exclude tags per bundle as needed.
-  - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript"
-  - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
-  - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
+ # - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript"
+ # - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
+ # - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
+ 
+ # ---- the following are Cathy specific
+   # run-js-tests.sh
+ # - export EXPRESS_JS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&@javascript&&@@blockmenuicons"
+ 
+ # behat-tests.sh
+ # - export EXPRESS_HEADLESS_BEHAT_TAGS="~@exclude_all_bundles&&~@broken&&~@javascript"
+ 
+  # also behat-tests.sh
+ # - export BUNDLE_BEHAT_TAGS="~@exclude_all_bundles&&~@broken"
+ 
+# ---- end Cathy specific
 
   # Copy scripts to root.
   - cp -R ${ROOT_DIR}/express/tests/travis-ci/* ${ROOT_DIR}

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -7,6 +7,8 @@ I should be able to attach Font Awesome icons to my block titles
 # TESTING NOTE: ATTACHING A BLOCK TO A PAGE IS VERY DIFFICULT WITH BEHAT; IT CAN BE DONE BUT THE
 # TEST IS NOT ROBUST - i.e IT'S EASY TO BREAK; SO IT HAS TO BE A HUMAN-RUN TEST, NOT AN AUTOMATED ONE
 
+# JAVASCRIPT TAG IS NECESSARY FOR TEST TO FIND #EDIT-ICON ELEMENT
+@javascript
 Scenario: An authenticated user can add an icon to a block title
 Given I am logged in as a user with the "site_owner" role
 And I am on "block/add/block"
@@ -14,8 +16,7 @@ And I am on "block/add/block"
 # And fill in "edit-title" with "Apple Info Block"
 And I fill in "Label" with "Apple Info Block"
 And fill in "Title" with "Apple Info Block"
-# And I follow "Disable rich-text"
-And I fill in "Body" with "A is for Apple"
+And I follow "Disable rich-text"
 And I press "Save"
 And I go to "block/apple-info-block/design"
 And I click the "#edit-icon a.fieldset-title" element

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -26,25 +26,3 @@ And I select "fa-apple" from "exbd_icon"
 And I press "edit-submit"
 #YES THE FOLLOWING LINE IS MISSPELLED IN WEB EXPRESS
 Then I should see "Block Desiger settings have been saved."
-
-# CREATE A BASIC PAGE
-Then I go to "node/add/page"
-And fill in "edit-title" with "About Apples"
-And I follow "Disable rich-text"
-And fill in "Body" with "The apple blossom is the state flower of Michigan."
-And I press "edit-submit"
-Then I should see "About Apples"
-
-# ADD BLOCK TO PAGE WITH LAYOUT
-# Then I follow "Edit Layout"
-# And I select "Text Block" from "edit-field-intro-und-actions-bundle--3"
-# And I fill in "edit-field-intro-und-form-label" with "Apple Info Block"
-# And fill in "edit-field-intro-und-form-title" with "Apple Info Block"
-# And I press 'Create block"
-
-# GO CHECK THE PAGE
-# And I go to "/about-apples"
-# Then I should see "About Apples"
-# And I should see "Learn More"
-# And the response should contain "fa fa-apple"
-# And the response should contain "class=\"exbd-block-icon fa fa-apple\""

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -10,12 +10,14 @@ Given I am logged in as a user with the "site_owner" role
 
 # CREATE A TEXT BLOCK AND ATTACH AN ICON TO IT
 And I am on "block/add/block"
-And I fill in "edit-label" with "Learn More"
-And fill in "edit-title" with "Learn More"
+And I fill in "edit-label" with "Apple Info Block"
+And fill in "edit-title" with "Apple Info Block"
 And I follow "Disable rich-text"
 And I fill in "Body" with "A is for Apple"
 And I press "Save"
-And I go to "block/learn-more/design"
+# And I go to "block/apple-info-block/design"
+# SEE IF FOLLOWING BLOCK DESIGNER WORKS
+And I follow "Block Designer"
 And I click the "#edit-icon a.fieldset-title" element
 And I select "fa-apple" from "exbd_icon"
 And I press "edit-submit"
@@ -30,22 +32,16 @@ And fill in "Body" with "The apple blossom is the state flower of Michigan."
 And I press "edit-submit"
 Then I should see "About Apples"
 
-# ADD BLOCK TO PAGE WITH CONTEXT
-Then I go to "admin/structure/context/add"
-And I fill in "edit-name" with "appleicon"
-And I select "path" from "edit-conditions-selector"
-And I fill in "edit-conditions-plugins-path-values" with "about-apples"
-And I select "block" from "edit-reactions-selector"
-# THE NEXT LINES SELECT THE TEXT BLOCK AND PLACE IT IN SIDEBAR LEFT REGION
-And I click the "#edit-reactions-plugins-block-selector-text-block a.fieldset-title" element
-And I check "edit-reactions-plugins-block-selector-text-block-checkboxes-bean-learn-more"
-And I click the ".context-blockform-regionlabel-content_sidebar_left a.add-block" element
-And I press "Save"
-Then I should see "appleicon has been created"
+# ADD BLOCK TO PAGE WITH LAYOUT
+# Then I follow "Edit Layout"
+# And I select "Text Block" from "edit-field-intro-und-actions-bundle--3"
+# And I fill in "edit-field-intro-und-form-label" with "Apple Info Block"
+# And fill in "edit-field-intro-und-form-title" with "Apple Info Block"
+# And I press 'Create block"
 
 # GO CHECK THE PAGE
- And I go to "/about-apples"
- Then I should see "About Apples"
- And I should see "Learn More"
- And the response should contain "fa fa-apple"
- And the response should contain "class=\"exbd-block-icon fa fa-apple\""
+# And I go to "/about-apples"
+# Then I should see "About Apples"
+# And I should see "Learn More"
+# And the response should contain "fa fa-apple"
+# And the response should contain "class=\"exbd-block-icon fa fa-apple\""

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -7,7 +7,7 @@ I should be able to attach Font Awesome icons to my block titles
 # TESTING NOTE: ATTACHING A BLOCK TO A PAGE IS VERY DIFFICULT WITH BEHAT; IT CAN BE DONE BUT THE
 # TEST IS NOT ROBUST - i.e IT'S EASY TO BREAK; SO IT HAS TO BE A HUMAN-RUN TEST, NOT AN AUTOMATED ONE
 
-# JAVASCRIPT TAG IS NECESSARY FOR TEST TO FIND #EDIT-ICON ELEMENT
+# JAVASCRIPT TAG IS NECESSARY FOR TEST TO FIND #EDIT-ICON ELEMENt
 @javascript
 Scenario: An authenticated user can add an icon to a block title
 Given I am logged in as a user with the "site_owner" role

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -4,6 +4,9 @@ In order to add visual interest to my site
 As an authenticated user
 I should be able to attach Font Awesome icons to my block titles
 
+# TESTING NOTE: ATTACHING A BLOCK TO A PAGE IS VERY DIFFICULT WITH BEHAT; 
+# IT CAN BE DONE BUT THE TEST IS NOT ROBUST; SO IT HAS TO BE A FUNCTIONAL TEST, NOT AN AUTOMATED ONE
+
 @javascript
 Scenario: An authenticated user can add an icon to a block title
 Given I am logged in as a user with the "site_owner" role

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -4,8 +4,8 @@ In order to add visual interest to my site
 As an authenticated user
 I should be able to attach Font Awesome icons to my block titles
 
-# TESTING NOTE: ATTACHING A BLOCK TO A PAGE IS VERY DIFFICULT WITH BEHAT; 
-# IT CAN BE DONE BUT THE TEST IS NOT ROBUST; SO IT HAS TO BE A HUMAN-RUN TEST, NOT AN AUTOMATED ONE
+# TESTING NOTE: ATTACHING A BLOCK TO A PAGE IS VERY DIFFICULT WITH BEHAT; IT CAN BE DONE BUT THE
+# TEST IS NOT ROBUST - i.e IT'S EASY TO BREAK; SO IT HAS TO BE A HUMAN-RUN TEST, NOT AN AUTOMATED ONE
 
 Scenario: An authenticated user can add an icon to a block title
 Given I am logged in as a user with the "site_owner" role

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -1,4 +1,4 @@
-@AdvDesign @blockmenuicons
+@AdvDesign @blocktitleicons
 Feature: Font Awesome Icons in block titles
 In order to add visual interest to my site
 As an authenticated user

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -38,7 +38,7 @@ And I fill in "edit-conditions-plugins-path-values" with "about-apples"
 And I select "block" from "edit-reactions-selector"
 And I click the "#edit-reactions-plugins-block-selector-text-block a.fieldset-title" element
 And I check "edit-reactions-plugins-block-selector-text-block-checkboxes-bean-learn-more"
-And I click the ".context-blockform-regionlabel-sidebar_second a.add-block" element
+And I click the ".context-blockform-regionlabel-content_bottom a.add-block" element
 And I press "Save"
 Then I should see "appleicon has been created"
 

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -4,20 +4,16 @@ In order to add visual interest to my site
 As an authenticated user
 I should be able to attach Font Awesome icons to my block titles
 
-# TESTING NOTE: ATTACHING A BLOCK TO A PAGE IS VERY DIFFICULT WITH BEHAT; IT CAN BE DONE BUT THE
-# TEST IS NOT ROBUST - i.e IT'S EASY TO BREAK; SO IT HAS TO BE A HUMAN-RUN TEST, NOT AN AUTOMATED ONE
+# TESTING NOTE: TO FULLY TEST THIS FUNCTIONALITY, THE BLOCK MUST BE PLACED ON A PAGE. THIS IS VERY DIFFICULT WITH BEHAT; 
+# IT CAN BE DONE BUT THE TEST IS NOT ROBUST - i.e IT'S EASY TO BREAK; SO THE FINAL STEP HAS TO BE HUMAN-RUN, NOT AUTOMATED
 
 Scenario: An authenticated user can add an icon to a block title
 Given I am logged in as a user with the "site_owner" role
 And I am on "block/add/block"
-# And I fill in "edit-label" with "Apple Info Block"
-# And fill in "edit-title" with "Apple Info Block"
 And I fill in "Label" with "Apple Info Block"
 And fill in "Title" with "Apple Info Block"
-# And I follow "Disable rich-text"
 And I press "Save"
 And I go to "block/apple-info-block/design"
-# And I click the "#edit-icon a.fieldset-title" element
 And I select "fa-apple" from "exbd_icon"
 And I press "edit-submit"
 #YES THE FOLLOWING LINE IS MISSPELLED IN WEB EXPRESS

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -38,7 +38,7 @@ And I fill in "edit-conditions-plugins-path-values" with "about-apples"
 And I select "block" from "edit-reactions-selector"
 And I click the "#edit-reactions-plugins-block-selector-text-block a.fieldset-title" element
 And I check "edit-reactions-plugins-block-selector-text-block-checkboxes-bean-learn-more"
-And I click the ".context-blockform-regionlabel-content_bottom a.add-block" element
+And I click the ".context-blockform-regionlabel-content_sidebar_left a.add-block" element
 And I press "Save"
 Then I should see "appleicon has been created"
 

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -1,0 +1,51 @@
+@AdvDesign @blockmenuicons
+Feature: Font Awesome Icons in block titles
+In order to add visual interest to my site
+As an authenticated user
+I should be able to attach Font Awesome icons to my block titles
+
+@javascript
+Scenario: An authenticated user can add an icon to a block title
+Given I am logged in as a user with the "site_owner" role
+
+# CREATE A TEXT BLOCK AND ATTACH AN ICON TO IT
+And I am on "block/add/block"
+And I fill in "edit-label" with "Learn More"
+And fill in "edit-title" with "Learn More"
+And I follow "Disable rich-text"
+And I fill in "Body" with "A is for Apple"
+And I press "Save"
+And I go to "block/learn-more/design"
+And I click the "#edit-icon a.fieldset-title" element
+And I select "fa-apple" from "exbd_icon"
+And I press "edit-submit"
+#YES THE FOLLOWING LINE IS MISSPELLED IN WEB EXPRESS
+Then I should see "Block Desiger settings have been saved."
+
+# CREATE A BASIC PAGE
+Then I go to "node/add/page"
+And fill in "edit-title" with "About Apples"
+And I follow "Disable rich-text"
+And fill in "Body" with "The apple blossom is the state flower of Michigan."
+And I press "edit-submit"
+Then I should see "About Apples"
+
+# ADD BLOCK TO PAGE WITH CONTEXT
+Then I go to "admin/structure/context/add"
+And I fill in "edit-name" with "appleicon"
+And I select "path" from "edit-conditions-selector"
+And I fill in "edit-conditions-plugins-path-values" with "about-apples"
+And I select "block" from "edit-reactions-selector"
+And I click the "#edit-reactions-plugins-block-selector-text-block a.fieldset-title" element
+And I check "edit-reactions-plugins-block-selector-text-block-checkboxes-bean-learn-more"
+And print last response
+And I click the ".context-blockform-regionlabel-sidebar_second a.add-block" element
+And I press "Save"
+Then I should see "appleicon has been created"
+
+# GO CHECK THE PAGE
+ And I go to "/about-apples"
+ Then I should see "About Apples"
+ And I should see "Learn More"
+ And the response should contain "fa fa-apple"
+ And the response should contain "class=\"exbd-block-icon fa fa-apple\""

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -1,26 +1,23 @@
-@AdvDesign
+@AdvancedDesign
 Feature: Font Awesome Icons in block titles
 In order to add visual interest to my site
 As an authenticated user
 I should be able to attach Font Awesome icons to my block titles
 
 # TESTING NOTE: ATTACHING A BLOCK TO A PAGE IS VERY DIFFICULT WITH BEHAT; 
-# IT CAN BE DONE BUT THE TEST IS NOT ROBUST; SO IT HAS TO BE A FUNCTIONAL TEST, NOT AN AUTOMATED ONE
+# IT CAN BE DONE BUT THE TEST IS NOT ROBUST; SO IT HAS TO BE A HUMAN-RUN TEST, NOT AN AUTOMATED ONE
 
-@javascript
 Scenario: An authenticated user can add an icon to a block title
 Given I am logged in as a user with the "site_owner" role
-
-# CREATE A TEXT BLOCK AND ATTACH AN ICON TO IT
 And I am on "block/add/block"
-And I fill in "edit-label" with "Apple Info Block"
-And fill in "edit-title" with "Apple Info Block"
-And I follow "Disable rich-text"
+# And I fill in "edit-label" with "Apple Info Block"
+# And fill in "edit-title" with "Apple Info Block"
+And I fill in "Label" with "Apple Info Block"
+And fill in "Title" with "Apple Info Block"
+# And I follow "Disable rich-text"
 And I fill in "Body" with "A is for Apple"
 And I press "Save"
 And I go to "block/apple-info-block/design"
-# SEE IF FOLLOWING BLOCK DESIGNER WORKS
-# And I follow "Block Designer" NO IT DOESN'T WORK; CAN'T BE FOUND
 And I click the "#edit-icon a.fieldset-title" element
 And I select "fa-apple" from "exbd_icon"
 And I press "edit-submit"

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -15,9 +15,9 @@ And fill in "edit-title" with "Apple Info Block"
 And I follow "Disable rich-text"
 And I fill in "Body" with "A is for Apple"
 And I press "Save"
-# And I go to "block/apple-info-block/design"
+And I go to "block/apple-info-block/design"
 # SEE IF FOLLOWING BLOCK DESIGNER WORKS
-And I follow "Block Designer"
+# And I follow "Block Designer" NO IT DOESN'T WORK; CAN'T BE FOUND
 And I click the "#edit-icon a.fieldset-title" element
 And I select "fa-apple" from "exbd_icon"
 And I press "edit-submit"

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -38,7 +38,6 @@ And I fill in "edit-conditions-plugins-path-values" with "about-apples"
 And I select "block" from "edit-reactions-selector"
 And I click the "#edit-reactions-plugins-block-selector-text-block a.fieldset-title" element
 And I check "edit-reactions-plugins-block-selector-text-block-checkboxes-bean-learn-more"
-And print last response
 And I click the ".context-blockform-regionlabel-sidebar_second a.add-block" element
 And I press "Save"
 Then I should see "appleicon has been created"

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -36,6 +36,7 @@ And I fill in "edit-name" with "appleicon"
 And I select "path" from "edit-conditions-selector"
 And I fill in "edit-conditions-plugins-path-values" with "about-apples"
 And I select "block" from "edit-reactions-selector"
+# THE NEXT LINES SELECT THE TEXT BLOCK AND PLACE IT IN SIDEBAR LEFT REGION
 And I click the "#edit-reactions-plugins-block-selector-text-block a.fieldset-title" element
 And I check "edit-reactions-plugins-block-selector-text-block-checkboxes-bean-learn-more"
 And I click the ".context-blockform-regionlabel-content_sidebar_left a.add-block" element

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -1,4 +1,4 @@
-@AdvDesign @blocktitleicons
+@AdvDesign
 Feature: Font Awesome Icons in block titles
 In order to add visual interest to my site
 As an authenticated user

--- a/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/blocktitleicons.feature
@@ -7,8 +7,6 @@ I should be able to attach Font Awesome icons to my block titles
 # TESTING NOTE: ATTACHING A BLOCK TO A PAGE IS VERY DIFFICULT WITH BEHAT; IT CAN BE DONE BUT THE
 # TEST IS NOT ROBUST - i.e IT'S EASY TO BREAK; SO IT HAS TO BE A HUMAN-RUN TEST, NOT AN AUTOMATED ONE
 
-# JAVASCRIPT TAG IS NECESSARY FOR TEST TO FIND #EDIT-ICON ELEMENt
-@javascript
 Scenario: An authenticated user can add an icon to a block title
 Given I am logged in as a user with the "site_owner" role
 And I am on "block/add/block"
@@ -16,10 +14,10 @@ And I am on "block/add/block"
 # And fill in "edit-title" with "Apple Info Block"
 And I fill in "Label" with "Apple Info Block"
 And fill in "Title" with "Apple Info Block"
-And I follow "Disable rich-text"
+# And I follow "Disable rich-text"
 And I press "Save"
 And I go to "block/apple-info-block/design"
-And I click the "#edit-icon a.fieldset-title" element
+# And I click the "#edit-icon a.fieldset-title" element
 And I select "fa-apple" from "exbd_icon"
 And I press "edit-submit"
 #YES THE FOLLOWING LINE IS MISSPELLED IN WEB EXPRESS

--- a/tests/behat/features/cu_advanced_design_bundle/context/context.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/context/context.feature
@@ -1,9 +1,10 @@
+@AdvancedDesign
 Feature: Context
 In order to place blocks and add background graphics
 As an authenticated user
 I should be able to access the full context features
 
-  @context @contextconditions @exclude_all_bundles
+@context @contextconditions @exclude_all_bundles
   Scenario Outline: A Site Owner should see a limited number of context conditions
     Given  I am logged in as a user with the "site_owner" role
     And am on "admin/structure/context/add"

--- a/tests/behat/features/cu_advanced_design_bundle/context/context.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/context/context.feature
@@ -1,8 +1,8 @@
 Feature: Context
 
   @context @contextconditions @exclude_all_bundles
-  Scenario Outline: A content_editor should see a limited number of context conditions
-    Given  I am logged in as a user with the "content_editor" role
+  Scenario Outline: A Site Owner should see a limited number of context conditions
+    Given  I am logged in as a user with the "site_owner" role
     And am on "admin/structure/context/add"
     When I select <condition> from "edit-conditions-selector"
 
@@ -21,8 +21,8 @@ Feature: Context
       | "Sitewide public" |
 
   @context @contextreactions @exclude_all_bundles
-  Scenario Outline: A content_editor should see a limited number of context reactions
-    Given  I am logged in as a user with the "content_editor" role
+  Scenario Outline: A Site Owner should see a limited number of context reactions
+    Given  I am logged in as a user with the "site_owner" role
     And am on "admin/structure/context/add"
     Then I select <reaction> from "edit-reactions-selector"
 

--- a/tests/behat/features/cu_advanced_design_bundle/context/context.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/context/context.feature
@@ -1,4 +1,7 @@
 Feature: Context
+In order to place blocks and add background graphics
+As an authenticated user
+I should be able to access the full context features
 
   @context @contextconditions @exclude_all_bundles
   Scenario Outline: A Site Owner should see a limited number of context conditions

--- a/tests/behat/features/cu_advanced_design_bundle/context/context.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/context/context.feature
@@ -4,7 +4,7 @@ In order to place blocks and add background graphics
 As an authenticated user
 I should be able to access the full context features
 
-@context @contextconditions @exclude_all_bundles
+@context @contextconditions
   Scenario Outline: A Site Owner should see a limited number of context conditions
     Given  I am logged in as a user with the "site_owner" role
     And am on "admin/structure/context/add"
@@ -24,7 +24,7 @@ I should be able to access the full context features
       | "Sitewide context" |
       | "Sitewide public" |
 
-  @context @contextreactions @exclude_all_bundles
+  @context @contextreactions
   Scenario Outline: A Site Owner should see a limited number of context reactions
     Given  I am logged in as a user with the "site_owner" role
     And am on "admin/structure/context/add"

--- a/tests/behat/features/cu_advanced_design_bundle/menuicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/menuicons.feature
@@ -1,0 +1,17 @@
+@AdvDesign
+Feature: Font Awesome Icons in menus
+In order to add visual interest to my site
+As an authenticated user
+I should be able to add icons to menu links
+
+Scenario: An authenticated user can add an icon to the main menu
+Given I am logged in as a user with the "site_owner" role
+And I am on "admin/structure/menu/manage/main-menu"
+And I fill in "edit-additem-title" with "Education"
+And I press "edit-submit" 
+Then the "edit-link-title" field should contain "Education"
+And I fill in "edit-link-path" with "https://www.colorado.edu/education"
+And I select "fa-bug" from "icon"
+And I press "Save"
+And I go to "/"
+Then the response should contain "class=\"fa fa-fw fa-bug\""

--- a/tests/behat/features/cu_advanced_design_bundle/menuicons.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/menuicons.feature
@@ -1,4 +1,4 @@
-@AdvDesign
+@AdvancedDesign
 Feature: Font Awesome Icons in menus
 In order to add visual interest to my site
 As an authenticated user

--- a/tests/behat/features/cu_advanced_design_bundle/stickymenu.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/stickymenu.feature
@@ -1,0 +1,14 @@
+@AdvDesign
+Feature: A Sticky Menu keeps the main navigation on the screen
+In order to make it easier for user to navigate on extra-long pages
+As an authenticated user
+I should be able to enable the Sticky Menu feature
+
+@api 
+Scenario: An authenticated user can enable Sticky Menu
+Given I am logged in as a user with the "site_owner" role
+ And I am on "admin/structure/menu/settings"
+ And I select "1" from "use_sticky_menu"
+ And I press "Save configuration"
+ And I go to "/"
+Then the response should contain "id=\"sticky-menu\""

--- a/tests/behat/features/cu_advanced_design_bundle/stickymenu.feature
+++ b/tests/behat/features/cu_advanced_design_bundle/stickymenu.feature
@@ -1,10 +1,9 @@
-@AdvDesign
+@AdvancedDesign
 Feature: A Sticky Menu keeps the main navigation on the screen
 In order to make it easier for user to navigate on extra-long pages
 As an authenticated user
 I should be able to enable the Sticky Menu feature
 
-@api 
 Scenario: An authenticated user can enable Sticky Menu
 Given I am logged in as a user with the "site_owner" role
  And I am on "admin/structure/menu/settings"


### PR DESCRIPTION
Tests:

- Block Title Icons: Test that icon can be added to block via Block Designer and that it displays on page
- Menu Icons: Test that an icon added to menu item will display
- Sticky Menu: Test that when it is enabled, it shows up
- Context conditions: change 'Content Editor' role to 'Site Owner' because CEs being downgraded, permission-wise.

