### PR TITLE
adding layout-boxed class to cushadow theme #2852

### DIFF
--- a/themes/cushadow/template.php
+++ b/themes/cushadow/template.php
@@ -19,4 +19,5 @@ function cushadow_preprocess_html(&$vars) {
   // SET BANNER COLOR (banner-white, banner-light, banner-dark, banner-black)
 
   $vars['classes_array'][]='banner-black';
+  $vars['classes_array'][]='layout-boxed';
 }


### PR DESCRIPTION
So the problem is that:
Shadow Theme + Node with Feature Layout + Hero Image in Content area == images breaks out of content boundary.

Closes #2852 