### PR TITLE
Bug/1815 Stringoverrides need empty array for context.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,26 @@
+Skip to content
+ 
+Search or jump to…
+
+Pull requests
+Issues
+Marketplace
+Explore
+ @cathysnider Sign out
+18
+18 6 CuBoulder/express 
+ Code
+ Issues 441
+ Pull requests 25
+ ZenHub
+ Wiki
+ Insights
+express/.travis.yml
+f4b5a0c  28 days ago
+@jeor0980 jeor0980 Reverting config for js tests in .yml file (#2853)
+@alexfinnarn @cathysnider @jwfuller @jeor0980 @kreynen
+     
+86 lines (66 sloc)  2.64 KB
 language: php
 # We want to avoid sudo. This allow us to use Travis docker infrastructure, which means builds start faster and have more CPU available.
 sudo: false
@@ -83,3 +106,16 @@ notifications:
     on_failure: always
     rooms:
       secure: q9Z3c6uNiCF+2l+BQsso1bQGbY0VmwXmw+StSlAGQxlccMh8HtDlrL4Rqk2ix0QMeGXffvLeATLThCq0ET9rmr9MIhTqRKfKgHUaQywiE3LZr+pgoPVGlqGbz1uSspWgWGkG3MWPtn1VC6pS4esm44YJ4mzucIKTswIe8DEWHTgi2Eju9P1w5HrtKBlM4+zxSwau5N5x+ol/LhafmvbODL5rBBH8lpErjVzSEf+5qQ/xu+I8tBdx7rqLmbbfPBXfn7Gx3THnaSG1WZZart6VXabbRdm029EWW6DxQQ6AyZTVwIHb59wrS3gL17SLsmvzXuYOlZMHBRTeAnt97czKILtoV/jscQE6z7AkPggaIFXcaWrvG+qSqZloym759i7YeYuwYdxy7QsDhNniHDXz3oP3jXJhN/TulYyuZYnPui5ihL3PHBoPy0t9PADeH8pxmhHrOB+t5WnQF02bAye6M4o0K+8HvUd24SgT4olUZbvNbuiwdZG0Ee4ZND4Azrd0W1LsyCPd8DJGsoaUe/KCtV8XdptgdIzpgfotDJMFnNK1QbSUUY5xigZoNEht7Gq7CruHFkM693FYDbJVCg9hlrtKafWaAvG8npvS5KPDxxHp7P6BgBOwtewzB3SpQuOSM/Y5qmO4U2lD6+nvzOihNUTVJYN7hO03fQFlI9M3E9o=
+© 2018 GitHub, Inc.
+Terms
+Privacy
+Security
+Status
+Help
+Contact GitHub
+Pricing
+API
+Training
+Blog
+About
+Press h to open a hovercard with more details.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,3 @@
-Skip to content
- 
-Search or jump to…
-
-Pull requests
-Issues
-Marketplace
-Explore
- @cathysnider Sign out
-18
-18 6 CuBoulder/express 
- Code
- Issues 441
- Pull requests 25
- ZenHub
- Wiki
- Insights
-express/.travis.yml
-f4b5a0c  28 days ago
-@jeor0980 jeor0980 Reverting config for js tests in .yml file (#2853)
-@alexfinnarn @cathysnider @jwfuller @jeor0980 @kreynen
-     
-86 lines (66 sloc)  2.64 KB
 language: php
 # We want to avoid sudo. This allow us to use Travis docker infrastructure, which means builds start faster and have more CPU available.
 sudo: false
@@ -106,16 +83,3 @@ notifications:
     on_failure: always
     rooms:
       secure: q9Z3c6uNiCF+2l+BQsso1bQGbY0VmwXmw+StSlAGQxlccMh8HtDlrL4Rqk2ix0QMeGXffvLeATLThCq0ET9rmr9MIhTqRKfKgHUaQywiE3LZr+pgoPVGlqGbz1uSspWgWGkG3MWPtn1VC6pS4esm44YJ4mzucIKTswIe8DEWHTgi2Eju9P1w5HrtKBlM4+zxSwau5N5x+ol/LhafmvbODL5rBBH8lpErjVzSEf+5qQ/xu+I8tBdx7rqLmbbfPBXfn7Gx3THnaSG1WZZart6VXabbRdm029EWW6DxQQ6AyZTVwIHb59wrS3gL17SLsmvzXuYOlZMHBRTeAnt97czKILtoV/jscQE6z7AkPggaIFXcaWrvG+qSqZloym759i7YeYuwYdxy7QsDhNniHDXz3oP3jXJhN/TulYyuZYnPui5ihL3PHBoPy0t9PADeH8pxmhHrOB+t5WnQF02bAye6M4o0K+8HvUd24SgT4olUZbvNbuiwdZG0Ee4ZND4Azrd0W1LsyCPd8DJGsoaUe/KCtV8XdptgdIzpgfotDJMFnNK1QbSUUY5xigZoNEht7Gq7CruHFkM693FYDbJVCg9hlrtKafWaAvG8npvS5KPDxxHp7P6BgBOwtewzB3SpQuOSM/Y5qmO4U2lD6+nvzOihNUTVJYN7hO03fQFlI9M3E9o=
-© 2018 GitHub, Inc.
-Terms
-Privacy
-Security
-Status
-Help
-Contact GitHub
-Pricing
-API
-Training
-Blog
-About
-Press h to open a hovercard with more details.

--- a/express.install
+++ b/express.install
@@ -129,12 +129,12 @@ function express_install() {
   variable_set('honeypot_log', 0);
   variable_set('honeypot_protect_all_forms', 1);
   variable_set('honeypot_time_limit', 0);
-  $locale_custom_strings_en = array(
+  $locale_custom_strings_en[''] = array(
     'Each menu has a corresponding block that is managed on the <a href="@blocks">Blocks administration page</a>.' => 'Each menu has a corresponding block which can be placed in a content region.',
     'Set and configure the default theme for your website.  Alternative <a href="@themes">themes</a> are available.' => 'Set and configure the default theme for your website.',
     'The menu module allows on-the-fly creation of menu links in the content authoring forms. To configure these settings for a particular content type, visit the <a href="@content-types">Content types</a> page, click the <em>edit</em> link for the content type, and go to the <em>Menu settings</em> section.' => 'The menu module allows on-the-fly creation of menu links.',
   );
-  variable_set('locale_custom_strings_en', serialize($locale_custom_strings_en));
+  variable_set('locale_custom_strings_en', $locale_custom_strings_en);
 
   variable_set('express_permissions_owner_cap', 5);
 

--- a/express.install
+++ b/express.install
@@ -134,7 +134,7 @@ function express_install() {
     'Set and configure the default theme for your website.  Alternative <a href="@themes">themes</a> are available.' => 'Set and configure the default theme for your website.',
     'The menu module allows on-the-fly creation of menu links in the content authoring forms. To configure these settings for a particular content type, visit the <a href="@content-types">Content types</a> page, click the <em>edit</em> link for the content type, and go to the <em>Menu settings</em> section.' => 'The menu module allows on-the-fly creation of menu links.',
   );
-  variable_set('locale_custom_strings_en', $locale_custom_strings_en);
+  variable_set('locale_custom_strings_en', serialize($locale_custom_strings_en));
 
   variable_set('express_permissions_owner_cap', 5);
 

--- a/modules/custom/cu_core/cu_core.install
+++ b/modules/custom/cu_core/cu_core.install
@@ -1037,9 +1037,21 @@ function cu_core_update_7052() {
 /**
  * Disable role_delegation for 3.0.0 release.
  */
-function cu_redirect_update_7053() {
+function cu_core_update_7053() {
   module_disable(array('role_delegation'));
   drupal_uninstall_modules(array('role_delegation'), $uninstall_dependents = FALSE);
+}
+
+/**
+ * Set stringoverrides correctly.
+ */
+function cu_core_update_7054() {
+  $locale_custom_strings_en[''] = array(
+    'Each menu has a corresponding block that is managed on the <a href="@blocks">Blocks administration page</a>.' => 'Each menu has a corresponding block which can be placed in a content region.',
+    'Set and configure the default theme for your website.  Alternative <a href="@themes">themes</a> are available.' => 'Set and configure the default theme for your website.',
+    'The menu module allows on-the-fly creation of menu links in the content authoring forms. To configure these settings for a particular content type, visit the <a href="@content-types">Content types</a> page, click the <em>edit</em> link for the content type, and go to the <em>Menu settings</em> section.' => 'The menu module allows on-the-fly creation of menu links.',
+  );
+  variable_set('locale_custom_strings_en', $locale_custom_strings_en);
 }
 
 

--- a/tests/behat/features/Express/menus/menus.feature
+++ b/tests/behat/features/Express/menus/menus.feature
@@ -61,8 +61,23 @@ Scenario: Access - An anonymous user should not be able to cannot add or edit me
   When I am on "admin/structure/menu"
   Then I should see "Access denied"
   
-# NOTE: THE MENUS SECTION HAS LINKS TO THE BLOCKS ADMIN PAGE AND CONTENT TYPES ADMIN PAGE
-# WHICH ARE OFF LIMITS TO ALL BUT DEVELOPERS
+# THIS SCENARIO TESTS FOR TEXT THAT KEEPS COMING BACK; See Issue/1815  
+Scenario: Functionality - The explanatory blurb should be "Each menu has a corresponding block which can be placed in a content region."
+ Given I am logged in as a user with the "site_owner" role
+And I am on "admin/structure/menu"
+Then I should see "Each menu has a corresponding block which can be placed in a content region"
+
+# NOTE: SOMETIMES THE MENUS SECTION REVERTS TO DISPLAYING LINKS TO THE BLOCKS ADMIN PAGE AND CONTENT TYPES ADMIN PAGE
+# VERIFY THAT THESE PAGES ARE OFF LIMITS TO ALL BUT DEVELOPERS
+Scenario Outline: Access - No one (but Devs) can access the Drupal System Block Admin page or Content Types page
+Given I am logged in as a user with the <role> role
+When I go to "admin/structure/block"
+Then I should see "Access denied"
+And I go to "admin/structure/types"
+Then I should see "Access denied"
+
+# NOTE: SOMETIMES THE MENUS SECTION REVERTS TO DISPLAYING LINKS TO THE BLOCKS ADMIN PAGE AND CONTENT TYPES ADMIN PAGE
+# VERIFY THAT THESE PAGES ARE OFF LIMITS TO ALL BUT DEVELOPE
 Scenario Outline: Access - No one (but Devs) can access the Drupal System Block Admin page or Content Types page
 Given I am logged in as a user with the <role> role
 When I go to "admin/structure/block"

--- a/tests/behat/features/Express/menus/menus.feature
+++ b/tests/behat/features/Express/menus/menus.feature
@@ -4,7 +4,7 @@ When I go to the Admin/Menu page
 As an Admin level user
 I can add and edit the menus on my site
   
-# The only users who can add or edit menus are Site Editor and up.
+# About Menu Perms: The only users who can add or edit menus are Site Editor and up.
 
 Scenario Outline: Access - An Admin level user should be able to add and edit all Express menus
   Given I am logged in as a user with the <role> role
@@ -57,18 +57,18 @@ Examples:
 | access_manager        | 
 | configuration_manager | 
 
-Scenario: Access - An anonymous user should not be able to cannot add or edit menus
+Scenario: Access - An anonymous user should not be able to add or edit menus
   When I am on "admin/structure/menu"
   Then I should see "Access denied"
   
 # THIS SCENARIO TESTS FOR TEXT THAT KEEPS COMING BACK; See Issue/1815  
 Scenario: Functionality - The explanatory blurb should be "Each menu has a corresponding block which can be placed in a content region."
- Given I am logged in as a user with the "site_owner" role
+Given I am logged in as a user with the "site_owner" role
 And I am on "admin/structure/menu"
 Then I should see "Each menu has a corresponding block which can be placed in a content region"
 
-# NOTE: SOMETIMES THE MENUS SECTION REVERTS TO DISPLAYING LINKS TO THE BLOCKS ADMIN PAGE AND CONTENT TYPES ADMIN PAGE
-# VERIFY THAT THESE PAGES ARE OFF LIMITS TO ALL BUT DEVELOPERS
+# NOTE: Sometimes the Menus Section reverts to old ways; and displays links to the Blocks Admin page and Content Types Admin page
+# This test verifys that these pages are off limits to all but developers V
 Scenario Outline: Access - No one (but Devs) can access the Drupal System Block Admin page or Content Types page
 Given I am logged in as a user with the <role> role
 When I go to "admin/structure/block"

--- a/tests/behat/features/Express/menus/menus.feature
+++ b/tests/behat/features/Express/menus/menus.feature
@@ -75,15 +75,6 @@ When I go to "admin/structure/block"
 Then I should see "Access denied"
 And I go to "admin/structure/types"
 Then I should see "Access denied"
-
-# NOTE: SOMETIMES THE MENUS SECTION REVERTS TO DISPLAYING LINKS TO THE BLOCKS ADMIN PAGE AND CONTENT TYPES ADMIN PAGE
-# VERIFY THAT THESE PAGES ARE OFF LIMITS TO ALL BUT DEVELOPE
-Scenario Outline: Access - No one (but Devs) can access the Drupal System Block Admin page or Content Types page
-Given I am logged in as a user with the <role> role
-When I go to "admin/structure/block"
-Then I should see "Access denied"
-And I go to "admin/structure/types"
-Then I should see "Access denied"
   
 Examples:
 | role                  |  


### PR DESCRIPTION
To stop the problem of https://github.com/CuBoulder/express/issues/1815 -- The text and link appearing on the List Menus tab has reverted to "Each menu has a corresponding block that is managed on the Blocks administration page." with a link to /admin/structure/block, which throws an 'Access denied' error.

closes #1815 