### PR TITLE
Feature/2926 Grant edit-my-content access for webform submitters.

### DIFF
--- a/modules/features/cu_ldap/cu_ldap.module
+++ b/modules/features/cu_ldap/cu_ldap.module
@@ -72,7 +72,7 @@ function cu_ldap_user_login_validate(&$form, &$form_state) {
     form_set_error('name', 'You do not have permission to edit this site. If you received an email invitation, please use the link provided.');
   }
   if ($roles < 2 && isset($_GET['destination']) && _is_node_form($nid) && !array_key_exists($account->name, $all)) {
-    $role = user_role_load_by_name("edit_only");
+    $role = user_role_load_by_name("edit_my_own");
     user_multiple_role_edit(array($uid), 'add_role', $role->rid);
     watchdog('cu_users_log', t('UID: %uid was given the role of edit_only to submit webforms.', array('%uid' => $uid)));
   }

--- a/modules/features/cu_ldap/cu_ldap.module
+++ b/modules/features/cu_ldap/cu_ldap.module
@@ -53,7 +53,7 @@ function cu_ldap_user_login_validate(&$form, &$form_state) {
 
   if ($roles < 2 && !isset($_GET['key']) && !$new_account && !array_key_exists($account->name, $all)) {
     // Notify user that they cannot log in to the site.
-    form_set_error('name', 'No roles associated with your account. If you received an email invitation, please use the link provided.');
+    form_set_error('name', 'You do not have permission to edit this site. If you received an email invitation, please use the link provided.');
   }
   if ($roles < 2 && !isset($_GET['key']) && $new_account && !array_key_exists($account->name, $all)) {
     // Delete account if it's new.
@@ -61,7 +61,7 @@ function cu_ldap_user_login_validate(&$form, &$form_state) {
     watchdog('cu_users_log', t('User tried to log in without roles and was deleted: %uid', array('%uid' => $uid)));
 
     // Notify user that they cannot log in to the site.
-    form_set_error('name', 'No roles associated with your account. If you received an email invitation, please use the link provided.');
+    form_set_error('name', 'You do not have permission to edit this site. If you received an email invitation, please use the link provided.');
   }
 }
 

--- a/modules/features/cu_ldap/cu_ldap.module
+++ b/modules/features/cu_ldap/cu_ldap.module
@@ -39,6 +39,11 @@ function cu_ldap_form_alter(&$form, &$form_state, $form_id) {
   }
 }
 
+function _is_node_form($nid) {
+  $node = node_load($nid);
+  return ($node->type == 'webform');
+}
+
 function cu_ldap_user_login_validate(&$form, &$form_state) {
   $uid = $form_state['uid'];
   $all = cu_users_get_users($type = 'all');
@@ -46,22 +51,30 @@ function cu_ldap_user_login_validate(&$form, &$form_state) {
   $account = user_load($uid);
   $roles = count($account->roles);
 
+  $dest = $_GET['destination'];
+  $nid = substr($dest, 5);
+
   // Delete the account if created less than 60 seconds ago.
   $time = time() - 60;
 
   $new_account = ($account->created > $time);
 
-  if ($roles < 2 && !isset($_GET['key']) && !$new_account && !array_key_exists($account->name, $all)) {
+  if ($roles < 2 && !isset($_GET['key']) && !$new_account && !_is_node_form($nid) && !array_key_exists($account->name, $all)) {
     // Notify user that they cannot log in to the site.
     form_set_error('name', 'You do not have permission to edit this site. If you received an email invitation, please use the link provided.');
   }
-  if ($roles < 2 && !isset($_GET['key']) && $new_account && !array_key_exists($account->name, $all)) {
+  if ($roles < 2 && !isset($_GET['key']) && $new_account && !_is_node_form($nid) && !array_key_exists($account->name, $all)) {
     // Delete account if it's new.
     user_delete($uid);
     watchdog('cu_users_log', t('User tried to log in without roles and was deleted: %uid', array('%uid' => $uid)));
 
     // Notify user that they cannot log in to the site.
     form_set_error('name', 'You do not have permission to edit this site. If you received an email invitation, please use the link provided.');
+  }
+  if ($roles < 2 && isset($_GET['destination']) && _is_node_form($nid) && !array_key_exists($account->name, $all)) {
+    $role = user_role_load_by_name("edit_only");
+    user_multiple_role_edit(array($uid), 'add_role', $role->rid);
+    watchdog('cu_users_log', t('UID: %uid was given the role of edit_only to submit webforms.', array('%uid' => $uid)));
   }
 }
 

--- a/modules/features/cu_ldap/cu_ldap.module
+++ b/modules/features/cu_ldap/cu_ldap.module
@@ -72,7 +72,7 @@ function cu_ldap_user_login_validate(&$form, &$form_state) {
     form_set_error('name', 'You do not have permission to edit this site. If you received an email invitation, please use the link provided.');
   }
   if ($roles < 2 && isset($_GET['destination']) && _is_node_form($nid) && !array_key_exists($account->name, $all)) {
-    $role = user_role_load_by_name("edit_my_own");
+    $role = user_role_load_by_name("edit_my_content");
     user_multiple_role_edit(array($uid), 'add_role', $role->rid);
     watchdog('cu_users_log', t('UID: %uid was given the role of edit_only to submit webforms.', array('%uid' => $uid)));
   }


### PR DESCRIPTION
When a unauthenticated user goes to a webform that requires LDAP authentication, they should be automatically given the 'edit-my-content' role (the one where you edit only stuff that you are the author of) and then forwarded to the form. 

Closes https://github.com/CuBoulder/express/issues/2926