### PR TITLE
Bug/2943 Content Editor (Edit Only) role should be able to edit Article and Article List Pages

### DIFF
--- a/tests/behat/features/cu_news_articles_bundle/2article.feature
+++ b/tests/behat/features/cu_news_articles_bundle/2article.feature
@@ -134,14 +134,14 @@ And I am on "admin/content"
 And I follow "Lunch is served at the Center for Community"
 Then I should see the link "View"
 # HIDE THE REST FOR NOW UNTIL PERMISSIONS ARE FIXED. 
-# And I should see the link "Edit"
-# And I should not see the link "Edit Layout"
+And I should see the link "Edit"
+And I should not see the link "Edit Layout"
 # And I should see the link "Revisions"
-# And I should see the link "Clear Page Cache"
-# When I follow "Edit"
-# Then I should see "This document is now locked against simultaneous editing."
-# And I should not see an "#edit-delete" element
-# And I press "Cancel edit"
+And I should see the link "Clear Page Cache"
+When I follow "Edit"
+Then I should see "This document is now locked against simultaneous editing."
+But I should not see an "#edit-delete" element
+And I press "Cancel edit"
 
 # EDIT MY CONTENT: ALL OTHER NODES 
 Scenario: Node Access - EditMyContent can not edit Article nodes

--- a/tests/behat/features/cu_news_articles_bundle/2article.feature
+++ b/tests/behat/features/cu_news_articles_bundle/2article.feature
@@ -1,4 +1,4 @@
-@newsArticle
+@newsArticles
 Feature: News and Articles
 In order to post timely news articles and aggregations
 As an authenticated user
@@ -23,7 +23,7 @@ Examples:
  Scenario: Node Access -  An anonymous user cannot add Article content
   When I am on "node/add/article"
   Then I should see "Access denied"
-  
+
 # 2) TEST THAT A SIMPLE NODE CAN BE CREATED AND REVISED
  Scenario: Node Functionality - A simple Article node can be created
  Given I am logged in as a user with the "site_owner" role
@@ -34,7 +34,7 @@ Examples:
  Then I should see "Article Lunch is served at the Center for Community has been created."
 And I should see "Enjoy many lucious desserts"
 
- 
+
 #  2.5 CREATE REVISIONS TO THE NEW NODE
 Scenario: Node functionality - Create node revision by adding graphics
 Given I am logged in as a user with the "site_owner" role
@@ -70,7 +70,7 @@ And I attach the file "ralphie.jpg" to "edit-field-article-thumbnail-und-0-uploa
  When I go to "/ralphie"
  Then I should see "An article about Ralphie"
  And I should not see "Lunch is served at the Center for Community"
- 
+
 # DATES CAN BE TURNED ON and OFF FOR DISPLAY ON ARTICLES
 # This is also tested in Express/cu_settings/articlesettings.feature
 Scenario: Article Date Display can be turned on and off site-wide
@@ -120,11 +120,11 @@ Then I should see "This document is now locked against simultaneous editing."
 And I should see an "#edit-delete" element
 And I press "Cancel edit"
 
-Examples: 
+Examples:
 | role |
-| developer       | 
-| administrator   | 
-| site_owner      | 
+| developer       |
+| administrator   |
+| site_owner      |
 | content_editor  |
 | site_editor |
 
@@ -133,7 +133,7 @@ Given I am logged in as a user with the "edit_only" role
 And I am on "admin/content"
 And I follow "Lunch is served at the Center for Community"
 Then I should see the link "View"
-# HIDE THE REST FOR NOW UNTIL PERMISSIONS ARE FIXED. 
+# HIDE THE REST FOR NOW UNTIL PERMISSIONS ARE FIXED.
 And I should see the link "Edit"
 And I should not see the link "Edit Layout"
 # And I should see the link "Revisions"
@@ -143,7 +143,7 @@ Then I should see "This document is now locked against simultaneous editing."
 But I should not see an "#edit-delete" element
 And I press "Cancel edit"
 
-# EDIT MY CONTENT: ALL OTHER NODES 
+# EDIT MY CONTENT: ALL OTHER NODES
 Scenario: Node Access - EditMyContent can not edit Article nodes
 Given I am logged in as a user with the "edit_my_content" role
 And I am on "admin/content"
@@ -151,4 +151,3 @@ And I follow "Lunch is served at the Center for Community"
 Then I should see the link "View"
 And I should not see the link "Edit"
 And I should not see the link "Clear Page Cache"
-

--- a/tests/behat/features/cu_news_articles_bundle/3articlelistpage.feature
+++ b/tests/behat/features/cu_news_articles_bundle/3articlelistpage.feature
@@ -26,7 +26,7 @@ I should be able to create, edit, and delete Article List Page content
     When I am on "node/add/article-list-page"
     Then I should see "Access denied"
     
- Scenario: A Simple Article List page display all articles created
+ Scenario: A Simple Article List page displays all articles created
 Given I am logged in as a user with the "site_owner" role
 When I go to "node/add/article-list-page"
 And  I fill in "edit-title" with "News Page"
@@ -34,5 +34,12 @@ And I press "Save"
 Then I should see "News Page"
 And I should see "An article about Ralphie"
 And I should see "Lunch is served at the Center for Community"
+
+Scenario: A user with the Edit Only role can edit but not delete Article List Pages
+    Given I am logged in as a user with the "edit_only" role 
+    And am on "news-page"
+    And I follow "Edit"
+    Then I should see "This document is now locked against simultaneous editing."
+    But I should not see "Delete"
     
    


### PR DESCRIPTION
Allow Content Editor (Edit Only) to edit an Article node and an Article List Page node.