### PR TITLE
Bug/3278 - Unrequire cu_slider module

### DIFF
--- a/modules/features/cu_slider/cu_slider.info
+++ b/modules/features/cu_slider/cu_slider.info
@@ -45,4 +45,3 @@ features[field_instance][] = field_collection_item-field_slider_slide-field_slid
 features[field_instance][] = field_collection_item-field_slider_slide-field_slider_image
 features[field_instance][] = field_collection_item-field_slider_slide-field_slider_link
 features[field_instance][] = field_collection_item-field_slider_slide-field_slider_teaser
-required = 1

--- a/modules/features/cu_slider/cu_slider.info
+++ b/modules/features/cu_slider/cu_slider.info
@@ -11,6 +11,7 @@ dependencies[] = fences
 dependencies[] = field_collection
 dependencies[] = field_group
 dependencies[] = image
+dependencies[] = libraries
 dependencies[] = link
 dependencies[] = list
 dependencies[] = options


### PR DESCRIPTION
Fixes #3278.
The `cu_slider` module is required in its `.info` file, so on new sites, it is enabled [before](https://git.drupalcode.org/project/drupal/blob/7.66/includes/install.core.inc#L1439) any of its dependencies, particularly `libraries`.

This is a problem for `install.php`, because after `cu_slider` is enabled, `cu_slider_init()` runs on each XHR to update the status bar and start another job in the "Install profile" step. Since `cu_slider_init()` [always calls](https://github.com/CuBoulder/express/blob/fb3ab43fec/modules/features/cu_slider/cu_slider.module#L38) `libraries_get_path()`, an error will occur.

If we unrequire `cu_slider`, it will be enabled after `libraries` is enabled, and the "Install profile" step of `install.php` is able to complete. Because `cu_slider` is a dependency of Express itself, it will always stay enabled, despite it not being required.

This pull request also makes `libraries` an explicit dependency of `cu_slider`.