### PR TITLE
Feature/2735 - Require exclusive LDAP authentication and unchangeable permissions forms in production

### DIFF
--- a/modules/custom/express_permissions/express_permissions.install
+++ b/modules/custom/express_permissions/express_permissions.install
@@ -1,6 +1,36 @@
 <?php
 
 /**
+ * Implements hook_requirements().
+ */
+function express_permissions_requirements($phase) {
+  $requirements = array();
+
+  // Ensure translations don't break during installation.
+  $t = get_t();
+
+  if ($phase === 'runtime') {
+    if (!variable_get('secure_permissions_disable_forms')) {
+      $requirements['express_permissions_forms'] = array(
+        'value' => $t('Not disabled'),
+        'description' => $t('In production, permissions and roles forms should be disabled. Go to the <a href="@url">Secure Permissions settings page</a> to disable them.', array('@url' => 'admin/config/people/secure_permissions')),
+        'severity' => variable_get('express_core_version') === 'cu_core' ? REQUIREMENT_ERROR : REQUIREMENT_INFO,
+      );
+    }
+    else {
+      $requirements['express_permissions_forms'] = array(
+        'value' => $t('Disabled'),
+        'severity' => REQUIREMENT_OK,
+      );
+    }
+
+    $requirements['express_permissions_forms']['title'] = $t('Permissions and roles forms');
+  }
+
+  return $requirements;
+}
+
+/**
  * Implements hook_install().
  *
  * Creates a set of default users with specified roles.

--- a/modules/features/cu_ldap/cu_ldap.install
+++ b/modules/features/cu_ldap/cu_ldap.install
@@ -1,6 +1,37 @@
 <?php
 
 /**
+ * Implements hook_requirements().
+ */
+function cu_ldap_requirements($phase) {
+  $requirements = array();
+
+  // Ensure translations don't break during installation.
+  $t = get_t();
+
+  if ($phase === 'runtime') {
+    $ldap_authentication_conf = variable_get('ldap_authentication_conf', array());
+    if (!(isset($ldap_authentication_conf['authenticationMode']) && $ldap_authentication_conf['authenticationMode'] === LDAP_AUTHENTICATION_EXCLUSIVE)) {
+      $requirements['cu_ldap_authentication_mode'] = array(
+        'value' => $t('Mixed'),
+        'description' => $t('When the authentication mode is mixed, Drupal authentication takes precedence over LDAP authentication. Change the authentication mode to LDAP only on the <a href="@url">LDAP Authentication settings page</a>.', array('@url' => url('admin/config/people/ldap/authentication'))),
+        'severity' => REQUIREMENT_ERROR,
+      );
+    }
+    else {
+      $requirements['cu_ldap_authentication_mode'] = array(
+        'value' => $t('Exclusive'),
+        'severity' => REQUIREMENT_OK,
+      );
+    }
+
+    $requirements['cu_ldap_authentication_mode']['title'] = $t('LDAP Authentication mode');
+  }
+
+  return $requirements;
+}
+
+/**
  * Add record to 'ldap_servers' so that features can compare code to db.
  */
 function cu_ldap_update_7001() {


### PR DESCRIPTION
Resolves #2735. Feel free to change requirement descriptions/values as needed.

Because **CU LDAP** is only enabled in production, its `hook_requirements()` implementation does not check whether we are in production.

The **Secure Permissions** requirements check determins whether we are in production [based on the contents](https://github.com/CuBoulder/express/commit/83aa6fef55#diff-284946ccf40e7d3dd14138f9d62ec7d7R17) of the `express_core_version` variable.

When not in production, the **Express Permissions** requirements check for secure permissions still runs, but its failure has only info-level severity, not error-level.